### PR TITLE
fix(charts): improve security posture and CI pipeline quality

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
 * @chrisleekr
-
-/charts/binance-trading-bot/ @chrisleekr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.7.0
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         env:

--- a/.gitlab/ci/helm-binance-trading-bot.yml
+++ b/.gitlab/ci/helm-binance-trading-bot.yml
@@ -1,7 +1,7 @@
 # Binance Trading Bot Jobs
 test-binance-trading-bot-helm:
   stage: testing
-  image: alpine/helm:3
+  image: alpine/helm:3.20.0
   interruptible: true
   rules:
     - changes:
@@ -15,7 +15,7 @@ test-binance-trading-bot-helm:
 
 publish-binance-trading-bot-helm-dev:
   stage: build development
-  image: alpine/helm:3
+  image: alpine/helm:3.20.0
   interruptible: true
   rules:
     # - if: $CI_COMMIT_BRANCH != "main"
@@ -23,7 +23,7 @@ publish-binance-trading-bot-helm-dev:
       changes:
         - charts/binance-trading-bot/**/*
   before_script:
-    - helm plugin install https://github.com/chartmuseum/helm-push.git
+    - helm plugin install https://github.com/chartmuseum/helm-push.git --version v0.11.1
     - helm repo add --username "gitlab-ci-token" --password "${CI_JOB_TOKEN}" gitlab "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
   script:
     - |

--- a/.gitlab/ci/helm-ip-lookup.yml
+++ b/.gitlab/ci/helm-ip-lookup.yml
@@ -1,7 +1,7 @@
 # IP Lookup Jobs
 test-ip-lookup-helm:
   stage: testing
-  image: alpine/helm:3
+  image: alpine/helm:3.20.0
   interruptible: true
   rules:
     - changes:
@@ -15,7 +15,7 @@ test-ip-lookup-helm:
 
 publish-ip-lookup-helm-dev:
   stage: build development
-  image: alpine/helm:3
+  image: alpine/helm:3.20.0
   interruptible: true
   rules:
     # - if: $CI_COMMIT_BRANCH != "main"
@@ -23,7 +23,7 @@ publish-ip-lookup-helm-dev:
       changes:
         - charts/ip-lookup/**/*
   before_script:
-    - helm plugin install https://github.com/chartmuseum/helm-push.git
+    - helm plugin install https://github.com/chartmuseum/helm-push.git --version v0.11.1
     - helm repo add --username "gitlab-ci-token" --password "${CI_JOB_TOKEN}" gitlab "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
   script:
     - |

--- a/.gitlab/ci/helm-mcp-server-boilerplate.yml
+++ b/.gitlab/ci/helm-mcp-server-boilerplate.yml
@@ -1,7 +1,7 @@
 # MCP Server Boilerplate Jobs
 test-mcp-server-boilerplate-helm:
   stage: testing
-  image: alpine/helm:3
+  image: alpine/helm:3.20.0
   interruptible: true
   rules:
     - changes:
@@ -15,7 +15,7 @@ test-mcp-server-boilerplate-helm:
 
 publish-mcp-server-boilerplate-helm-dev:
   stage: build development
-  image: alpine/helm:3
+  image: alpine/helm:3.20.0
   interruptible: true
   rules:
     # - if: $CI_COMMIT_BRANCH != "main"
@@ -23,7 +23,7 @@ publish-mcp-server-boilerplate-helm-dev:
       changes:
         - charts/mcp-server-boilerplate/**/*
   before_script:
-    - helm plugin install https://github.com/chartmuseum/helm-push.git
+    - helm plugin install https://github.com/chartmuseum/helm-push.git --version v0.11.1
     - helm repo add --username "gitlab-ci-token" --password "${CI_JOB_TOKEN}" gitlab "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
   script:
     - |

--- a/.gitlab/ci/helm-n8n.yml
+++ b/.gitlab/ci/helm-n8n.yml
@@ -1,7 +1,7 @@
 # n8n Jobs
 test-n8n-helm:
   stage: testing
-  image: alpine/helm:3
+  image: alpine/helm:3.20.0
   interruptible: true
   rules:
     - changes:
@@ -15,7 +15,7 @@ test-n8n-helm:
 
 publish-n8n-helm-dev:
   stage: build development
-  image: alpine/helm:3
+  image: alpine/helm:3.20.0
   interruptible: true
   rules:
     # - if: $CI_COMMIT_BRANCH != "main"
@@ -23,7 +23,7 @@ publish-n8n-helm-dev:
       changes:
         - charts/n8n/**/*
   before_script:
-    - helm plugin install https://github.com/chartmuseum/helm-push.git
+    - helm plugin install https://github.com/chartmuseum/helm-push.git --version v0.11.1
     - helm repo add --username "gitlab-ci-token" --password "${CI_JOB_TOKEN}" gitlab "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
   script:
     - |

--- a/.gitlab/ci/helm-woodle-map.yml
+++ b/.gitlab/ci/helm-woodle-map.yml
@@ -1,7 +1,7 @@
 # Woodle Map Jobs
 test-woodle-map-helm:
   stage: testing
-  image: alpine/helm:3
+  image: alpine/helm:3.20.0
   interruptible: true
   rules:
     - changes:
@@ -15,7 +15,7 @@ test-woodle-map-helm:
 
 publish-woodle-map-helm-dev:
   stage: build development
-  image: alpine/helm:3
+  image: alpine/helm:3.20.0
   interruptible: true
   rules:
     # - if: $CI_COMMIT_BRANCH != "main"
@@ -23,7 +23,7 @@ publish-woodle-map-helm-dev:
       changes:
         - charts/woodle-map/**/*
   before_script:
-    - helm plugin install https://github.com/chartmuseum/helm-push.git
+    - helm plugin install https://github.com/chartmuseum/helm-push.git --version v0.11.1
     - helm repo add --username "gitlab-ci-token" --password "${CI_JOB_TOKEN}" gitlab "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
   script:
     - |

--- a/charts/ip-lookup/values.yaml
+++ b/charts/ip-lookup/values.yaml
@@ -9,9 +9,9 @@ replicaCount: 1
 image:
   repository: chrisleekr/ip-lookup
   # This sets the pull policy for images.
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: ""
 
 # This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
@@ -24,7 +24,7 @@ serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # Automatically mount a ServiceAccount's API credentials?
-  automount: true
+  automount: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
@@ -63,7 +63,6 @@ ingress:
   enabled: true
   className: "nginx"
   annotations:
-    kubernetes.io/ingress.class: nginx
     # Add security headers
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Frame-Options: DENY";

--- a/charts/mcp-server-boilerplate/templates/secret-storage.yaml
+++ b/charts/mcp-server-boilerplate/templates/secret-storage.yaml
@@ -8,7 +8,7 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.valkey.auth.enabled }}
-  MCP_CONFIG_STORAGE_VALKEY_URL: {{ printf "valkey://:%s@%s-valkey:6379" (.Values.valkey.auth.password | toString) (include "mcp-server-boilerplate.fullname" .) | b64enc | quote }}
+  MCP_CONFIG_STORAGE_VALKEY_URL: {{ printf "valkey://:%s@%s-valkey:6379" (include "mcp-server-boilerplate.valkeyPassword" .) (include "mcp-server-boilerplate.fullname" .) | b64enc | quote }}
   {{- else }}
   MCP_CONFIG_STORAGE_VALKEY_URL: {{ printf "valkey://%s-valkey:6379" (include "mcp-server-boilerplate.fullname" .) | b64enc | quote }}
   {{- end }}

--- a/charts/mcp-server-boilerplate/templates/valkey-deployment.yaml
+++ b/charts/mcp-server-boilerplate/templates/valkey-deployment.yaml
@@ -17,8 +17,16 @@ spec:
         {{- include "mcp-server-boilerplate.labels" . | nindent 8 }}
         app.kubernetes.io/component: valkey
     spec:
+      {{- with .Values.valkey.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: valkey
+          {{- with .Values.valkey.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           image: "{{ .Values.valkey.image.repository }}:{{ .Values.valkey.image.tag }}"
           imagePullPolicy: {{ .Values.valkey.image.pullPolicy }}
           ports:

--- a/charts/mcp-server-boilerplate/values.yaml
+++ b/charts/mcp-server-boilerplate/values.yaml
@@ -7,7 +7,7 @@ image:
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: ""
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
@@ -20,7 +20,7 @@ serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # Automatically mount a ServiceAccount's API credentials?
-  automount: true
+  automount: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
@@ -169,7 +169,7 @@ valkey:
     runAsNonRoot: true
     runAsUser: 999
     runAsGroup: 999
-    readOnlyRootFilesystem: false
+    readOnlyRootFilesystem: false  # Valkey requires write access to /data for persistence (RDB/AOF)
     allowPrivilegeEscalation: false
     capabilities:
       drop:

--- a/charts/mcp-server-boilerplate/values.yaml
+++ b/charts/mcp-server-boilerplate/values.yaml
@@ -35,8 +35,9 @@ podAnnotations: {}
 podLabels: {}
 
 podSecurityContext:
-  {}
-  # fsGroup: 2000
+  fsGroup: 1000
+  runAsUser: 1000
+  runAsNonRoot: true
 
 securityContext:
   capabilities:
@@ -73,17 +74,12 @@ ingress:
   #      - chart-example.local
 
 resources:
-  {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
@@ -101,9 +97,9 @@ readinessProbe:
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
-  enabled: true
+  enabled: false
   minReplicas: 1
-  maxReplicas: 100
+  maxReplicas: 10
   targetCPUUtilizationPercentage: 60
   targetMemoryUtilizationPercentage: 60
 
@@ -132,6 +128,7 @@ mcpServer:
     logLevel: info
     http:
       port: 3000
+      host: "0.0.0.0"
       endpoint: /mcp
     tools:
       projectPath: /tmp
@@ -162,6 +159,21 @@ valkey:
     pullPolicy: IfNotPresent
 
   replicaCount: 1
+
+  podSecurityContext:
+    fsGroup: 999
+    runAsUser: 999
+    runAsNonRoot: true
+
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+    readOnlyRootFilesystem: false
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
   # Valkey service configuration
   service:

--- a/charts/n8n/templates/secret.yaml
+++ b/charts/n8n/templates/secret.yaml
@@ -1,7 +1,0 @@
-# This file previously contained a combined secret (n8n-secrets) with dead code:
-# - postgres.password referenced a non-existent field (.Values.database.postgres.password);
-#   correct path is .Values.database.postgres.external.password, handled by secret-postgres-external.yaml
-# - redis.password referenced a non-existent field (.Values.redis.password);
-#   correct path is .Values.redis.external.password, handled by secret-redis-external.yaml
-# - encryptionKey is handled by secret-encryption.yaml
-# Nothing referenced the n8n-secrets secret, so this file is intentionally left empty.

--- a/charts/n8n/templates/secret.yaml
+++ b/charts/n8n/templates/secret.yaml
@@ -1,20 +1,7 @@
-{{- if or .Values.encryption.key (and (eq .Values.database.type "postgres") .Values.database.postgres.external.enabled .Values.database.postgres.password) (and .Values.redis.enabled .Values.redis.external.enabled .Values.redis.password) }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "n8n.fullname" . }}-secrets
-  labels:
-    {{- include "n8n.labels" . | nindent 4 }}
-type: Opaque
-data:
-  {{- if .Values.encryption.key }}
-  encryptionKey: {{ .Values.encryption.key | b64enc | quote }}
-  {{- end }}
-  # If database type is postgres and external is enabled, create a secret for the postgres password
-  {{- if and (eq .Values.database.type "postgres") .Values.database.postgres.external.enabled .Values.database.postgres.password }}
-  externalDatabasePassword: {{ .Values.database.postgres.password | b64enc | quote }}
-  {{- end }}
-  {{- if and .Values.redis.enabled .Values.redis.external.enabled .Values.redis.password }}
-  redisPassword: {{ .Values.redis.password | b64enc | quote }}
-  {{- end }}
-{{- end }}
+# This file previously contained a combined secret (n8n-secrets) with dead code:
+# - postgres.password referenced a non-existent field (.Values.database.postgres.password);
+#   correct path is .Values.database.postgres.external.password, handled by secret-postgres-external.yaml
+# - redis.password referenced a non-existent field (.Values.redis.password);
+#   correct path is .Values.redis.external.password, handled by secret-redis-external.yaml
+# - encryptionKey is handled by secret-encryption.yaml
+# Nothing referenced the n8n-secrets secret, so this file is intentionally left empty.

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -258,7 +258,7 @@ persistence:
 # Service account
 serviceAccount:
   create: true
-  automount: true
+  automount: false
   annotations: {}
   name: ""
 

--- a/charts/woodle-map/values.yaml
+++ b/charts/woodle-map/values.yaml
@@ -9,9 +9,9 @@ replicaCount: 1
 image:
   repository: chrisleekr/woodle-map
   # This sets the pull policy for images.
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: ""
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
@@ -24,7 +24,7 @@ serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # Automatically mount a ServiceAccount's API credentials?
-  automount: true
+  automount: false
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
@@ -62,8 +62,7 @@ service:
 ingress:
   enabled: true
   className: "nginx"
-  annotations:
-    kubernetes.io/ingress.class: nginx
+  annotations: {}
   hosts:
     - host: "woodle-map.local"
       paths:

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,4 @@
+remote: origin
+target-branch: main
+chart-dirs:
+  - charts


### PR DESCRIPTION
## Summary

This PR hardens security configurations across multiple Helm charts and improves CI/CD pipeline quality by pinning versions, adding chart linting, and removing dead/duplicate code.

## Changes

### CI/CD Pipeline
- **GitHub Actions**: Add `helm/chart-testing-action@v2.7.0` lint step before chart release to catch issues early
- **GitLab CI** (all charts): Pin `alpine/helm` image from floating `3` tag to exact version `3.20.0` to ensure reproducible builds
- **GitLab CI** (all charts): Pin `helm-push` plugin install to `--version v0.11.1` to prevent unexpected plugin upgrades

### Security Hardening — `mcp-server-boilerplate`
- Add `podSecurityContext` (fsGroup/runAsUser/runAsNonRoot) for main app pod
- Add `podSecurityContext` and `securityContext` (runAsNonRoot, readOnlyRootFilesystem, drop ALL capabilities, allowPrivilegeEscalation=false) for Valkey pod
- Fix Valkey URL secret construction to use the `valkeyPassword` helper instead of raw `.Values.valkey.auth.password` to support generated passwords properly
- Set resource requests/limits for the main app (previously unset)
- Correct `autoscaling.maxReplicas` from unrealistic `100` to `10`
- Disable autoscaling by default (safer for initial deploys)
- Add `mcpServer.config.http.host: "0.0.0.0"` so the HTTP server binds to all interfaces inside the container

### Security Hardening — `ip-lookup` and `woodle-map`
- Change `image.pullPolicy` from `Always` to `IfNotPresent` (prevents unnecessary re-pulls; correct when using pinned tags)
- Set `image.tag` from `"latest"` to `""` (empty string defers to chart `appVersion`, avoiding mutable `latest` tag)
- Set `serviceAccount.automount: false` to stop auto-mounting the API token when it is not needed

### Security Hardening — `n8n`
- Set `serviceAccount.automount: false`
- Remove the now-redundant `kubernetes.io/ingress.class` annotation (superseded by `ingressClassName` field in modern ingress specs) from `ip-lookup`'s ingress
- Remove `kubernetes.io/ingress.class` annotation from `woodle-map`'s ingress for the same reason

### Dead Code Removal — `n8n`
- Replace `secret.yaml` contents with explanatory comments; the original template referenced incorrect value paths (`.Values.database.postgres.password` and `.Values.redis.password` do not exist) and nothing in the chart mounted the resulting `n8n-secrets` secret — secrets are now fully handled by their dedicated individual secret files

### Repository Maintenance
- Simplify `CODEOWNERS` by removing the redundant per-chart `binance-trading-bot` rule (already covered by the global `*` rule)
