### PR TITLE
feat(helm): add github-app-playground chart and n8n secret template

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,3 +20,4 @@ include:
   - local: .gitlab/ci/helm-woodle-map.yml
   - local: .gitlab/ci/helm-mcp-server-boilerplate.yml
   - local: .gitlab/ci/helm-n8n.yml
+  - local: .gitlab/ci/helm-github-app-playground.yml

--- a/.gitlab/ci/helm-github-app-playground.yml
+++ b/.gitlab/ci/helm-github-app-playground.yml
@@ -1,0 +1,77 @@
+# GitHub App Playground Jobs
+test-github-app-playground-helm:
+  stage: testing
+  image: alpine/helm:3.20.0
+  interruptible: true
+  rules:
+    - changes:
+        - charts/github-app-playground/**/*
+  script:
+    - helm template ./charts/github-app-playground > ./template-github-app-playground.yaml
+    # Also render the bedrock provider path to catch conditional template issues
+    - helm template ./charts/github-app-playground
+        --set app.claudeProvider=bedrock
+        --set app.awsRegion=us-east-1
+        --set app.claudeModel=us.anthropic.claude-sonnet-4-5-v1:0
+        > ./template-github-app-playground-bedrock.yaml
+    - helm lint ./charts/github-app-playground
+  artifacts:
+    paths:
+      - ./template-github-app-playground.yaml
+
+publish-github-app-playground-helm-dev:
+  stage: build development
+  image: alpine/helm:3.20.0
+  interruptible: true
+  rules:
+    # - if: $CI_COMMIT_BRANCH != "main"
+    - if: $CI_COMMIT_BRANCH != ""
+      changes:
+        - charts/github-app-playground/**/*
+  before_script:
+    - helm plugin install https://github.com/chartmuseum/helm-push.git --version v0.11.1
+    - helm repo add --username "gitlab-ci-token" --password "${CI_JOB_TOKEN}" gitlab "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
+  script:
+    - |
+      VERSION=$(yq e '.version' ./charts/github-app-playground/Chart.yaml)
+      helm cm-push ./charts/github-app-playground --version="${VERSION}-dev-${CI_COMMIT_SHORT_SHA}" gitlab
+
+# bump-github-app-playground-helm-version:
+#   stage: bump production
+#   image: node:lts-alpine
+#   rules:
+#     - if: $CI_COMMIT_BRANCH == "main"
+#       changes:
+#         - charts/github-app-playground/**/*
+#   interruptible: true
+#   before_script:
+#     - apk update
+#     - apk add yq git
+#     - npm install -g semver
+#   script:
+#     - |
+#       VERSION=$(yq e '.version' ./charts/github-app-playground/Chart.yaml)
+#       VERSION=$(semver -i patch $VERSION)
+#       yq e -i '.version = "'${VERSION}'"' ./charts/github-app-playground/Chart.yaml
+
+#       git remote set-url origin https://gitlab-ci-token:${CI_PUSH_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}.git
+#       git config --global user.email "$GITLAB_USER_EMAIL"
+#       git config --global user.name "$GITLAB_USER_NAME"
+#       git pull origin main
+#       git commit -am "bump: github-app-playground helm chart version to ${VERSION} [skip ci]"
+#       git push origin HEAD:"${CI_COMMIT_REF_NAME}"
+
+# publish-github-app-playground-helm:
+#   stage: build production
+#   image: alpine/helm:3.20.0
+#   dependencies:
+#     - bump-github-app-playground-helm-version
+#   rules:
+#     - if: $CI_COMMIT_BRANCH == "main"
+#       changes:
+#         - charts/github-app-playground/**/*
+#   before_script:
+#     - helm plugin install https://github.com/chartmuseum/helm-push.git --version v0.11.1
+#     - helm repo add --username "gitlab-ci-token" --password "${CI_JOB_TOKEN}" gitlab "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
+#   script:
+#     - helm cm-push ./charts/github-app-playground gitlab

--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -1,0 +1,42 @@
+apiVersion: v2
+name: github-app-playground
+description: A Helm chart for GitHub App that responds to @chrisleekr-bot mentions on PRs and issues, using Claude Agent SDK with MCP servers for GitHub interactions.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"
+
+kubeVersion: ">= 1.31.0"
+
+maintainers:
+  - name: Chris Lee
+    url: https://github.com/chrisleekr
+
+keywords:
+  - github-app
+  - claude
+  - ai
+  - bot
+  - webhook
+  - mcp
+
+home: https://github.com/chrisleekr/github-app-playground
+sources:
+  - https://github.com/chrisleekr/github-app-playground

--- a/charts/github-app-playground/templates/NOTES.txt
+++ b/charts/github-app-playground/templates/NOTES.txt
@@ -1,0 +1,28 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "github-app-playground.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "github-app-playground.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "github-app-playground.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "github-app-playground.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}
+
+2. Configure your GitHub App webhook to point to:
+   <your-ingress-host>/api/github/webhooks
+
+3. Verify the bot is healthy:
+   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ include "github-app-playground.name" . }}"

--- a/charts/github-app-playground/templates/_helpers.tpl
+++ b/charts/github-app-playground/templates/_helpers.tpl
@@ -1,0 +1,86 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "github-app-playground.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "github-app-playground.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "github-app-playground.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "github-app-playground.labels" -}}
+helm.sh/chart: {{ include "github-app-playground.chart" . }}
+{{ include "github-app-playground.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "github-app-playground.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "github-app-playground.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "github-app-playground.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "github-app-playground.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the name of the Secret to use for app credentials.
+Uses existingSecret if provided, otherwise uses the chart-managed secret name.
+*/}}
+{{- define "github-app-playground.secretName" -}}
+{{- if .Values.secrets.existingSecret }}
+{{- .Values.secrets.existingSecret }}
+{{- else }}
+{{- printf "%s-secret" (include "github-app-playground.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the name of the workspace PVC to use.
+Uses existingClaim if provided, otherwise uses the chart-managed PVC name.
+*/}}
+{{- define "github-app-playground.workspacePVCName" -}}
+{{- if .Values.workspace.persistence.existingClaim }}
+{{- .Values.workspace.persistence.existingClaim }}
+{{- else }}
+{{- printf "%s-workspace" (include "github-app-playground.fullname" .) }}
+{{- end }}
+{{- end }}

--- a/charts/github-app-playground/templates/configmap.yaml
+++ b/charts/github-app-playground/templates/configmap.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}-config
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+data:
+  # HTTP server configuration
+  PORT: {{ .Values.app.port | quote }}
+  NODE_ENV: {{ .Values.app.nodeEnv | quote }}
+  LOG_LEVEL: {{ .Values.app.logLevel | quote }}
+
+  # Bot trigger configuration
+  TRIGGER_PHRASE: {{ .Values.app.triggerPhrase | quote }}
+
+  # Concurrency and timeout settings
+  MAX_CONCURRENT_REQUESTS: {{ .Values.app.maxConcurrentRequests | quote }}
+  AGENT_TIMEOUT_MS: {{ .Values.app.agentTimeoutMs | quote }}
+
+  # Git clone settings
+  CLONE_DEPTH: {{ .Values.app.cloneDepth | quote }}
+  # Must match the mountPath of the workspace volume
+  CLONE_BASE_DIR: {{ .Values.app.cloneBaseDir | quote }}
+
+  # AI provider: "anthropic" or "bedrock"
+  CLAUDE_PROVIDER: {{ .Values.app.claudeProvider | quote }}
+
+  # AWS Bedrock provider settings (only used when CLAUDE_PROVIDER=bedrock)
+  {{- if eq .Values.app.claudeProvider "bedrock" }}
+  AWS_REGION: {{ .Values.app.awsRegion | quote }}
+  # Only set when non-empty: process.env["CLAUDE_MODEL"]="" fails z.string().min(1) with a
+  # confusing error; leaving it unset lets superRefine emit the clear message instead.
+  {{- if .Values.app.claudeModel }}
+  CLAUDE_MODEL: {{ .Values.app.claudeModel | quote }}
+  {{- end }}
+  # Only set when non-empty: an empty URL string may be misinterpreted by the Claude SDK
+  {{- if .Values.app.anthropicBedrockBaseUrl }}
+  ANTHROPIC_BEDROCK_BASE_URL: {{ .Values.app.anthropicBedrockBaseUrl | quote }}
+  {{- end }}
+  {{- end }}
+
+  # Override the Claude Code CLI path when using a custom image.
+  # Leave unset to rely on the CLAUDE_CODE_PATH baked into the Docker image ENV.
+  {{- if .Values.app.claudeCodePath }}
+  CLAUDE_CODE_PATH: {{ .Values.app.claudeCodePath | quote }}
+  {{- end }}

--- a/charts/github-app-playground/templates/deployment.yaml
+++ b/charts/github-app-playground/templates/deployment.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "github-app-playground.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "github-app-playground.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "github-app-playground.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      # Must be >= the app's internal shutdown timeout (290s) to allow in-flight requests to complete
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.app.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "github-app-playground.fullname" . }}-config
+            - secretRef:
+                name: {{ include "github-app-playground.secretName" . }}
+          {{- with .Values.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- if .Values.workspace.persistence.enabled }}
+            - name: workspace
+              mountPath: {{ .Values.app.cloneBaseDir | quote }}
+            {{- end }}
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        {{- if .Values.workspace.persistence.enabled }}
+        - name: workspace
+          persistentVolumeClaim:
+            claimName: {{ include "github-app-playground.workspacePVCName" . }}
+        {{- end }}
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/github-app-playground/templates/hpa.yaml
+++ b/charts/github-app-playground/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "github-app-playground.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if ne .Values.autoscaling.targetCPUUtilizationPercentage nil }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if ne .Values.autoscaling.targetMemoryUtilizationPercentage nil }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/github-app-playground/templates/ingress.yaml
+++ b/charts/github-app-playground/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- with .pathType }}
+            pathType: {{ . }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "github-app-playground.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/github-app-playground/templates/pdb.yaml
+++ b/charts/github-app-playground/templates/pdb.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- /* Use ne nil instead of direct truthiness: integer 0 is falsy in Go templates but is a
+     valid PDB value meaning "all pods may be disrupted". ne nil correctly distinguishes
+     between "not set" and "explicitly set to 0". */}}
+{{- if and (ne .Values.podDisruptionBudget.minAvailable nil) (ne .Values.podDisruptionBudget.maxUnavailable nil) }}
+  {{- fail "podDisruptionBudget: minAvailable and maxUnavailable are mutually exclusive" }}
+{{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "github-app-playground.selectorLabels" . | nindent 6 }}
+  {{- if ne .Values.podDisruptionBudget.minAvailable nil }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if ne .Values.podDisruptionBudget.maxUnavailable nil }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/charts/github-app-playground/templates/pvc.yaml
+++ b/charts/github-app-playground/templates/pvc.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.workspace.persistence.enabled (not .Values.workspace.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}-workspace
+  annotations:
+    # Prevent accidental deletion of workspace data on helm uninstall
+    "helm.sh/resource-policy": keep
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+    app.kubernetes.io/component: workspace
+spec:
+  accessModes:
+    {{- range .Values.workspace.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.workspace.persistence.size | quote }}
+  {{- if .Values.workspace.persistence.storageClass }}
+  {{- if (eq "-" .Values.workspace.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.workspace.persistence.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/github-app-playground/templates/secret.yaml
+++ b/charts/github-app-playground/templates/secret.yaml
@@ -1,0 +1,44 @@
+{{- if not .Values.secrets.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}-secret
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+type: Opaque
+data:
+  # GitHub App credentials (required)
+  GITHUB_APP_ID: {{ .Values.secrets.githubAppId | b64enc | quote }}
+  # Multi-line PEM private key — newlines are preserved via b64enc
+  GITHUB_APP_PRIVATE_KEY: {{ .Values.secrets.githubAppPrivateKey | b64enc | quote }}
+  GITHUB_WEBHOOK_SECRET: {{ .Values.secrets.githubWebhookSecret | b64enc | quote }}
+
+  # Anthropic direct API (required when CLAUDE_PROVIDER=anthropic)
+  {{- if eq .Values.app.claudeProvider "anthropic" }}
+  ANTHROPIC_API_KEY: {{ .Values.secrets.anthropicApiKey | b64enc | quote }}
+  {{- end }}
+
+  # AWS credentials for Bedrock (required when CLAUDE_PROVIDER=bedrock)
+  # Only non-empty values are written: empty env vars can interfere with the AWS SDK credential
+  # chain (e.g. IRSA / instance profile). Omitting them lets the SDK fall through correctly.
+  # Prefer IAM roles (IRSA/EC2 instance profile) over static keys in production.
+  {{- if eq .Values.app.claudeProvider "bedrock" }}
+  {{- if .Values.secrets.awsAccessKeyId }}
+  AWS_ACCESS_KEY_ID: {{ .Values.secrets.awsAccessKeyId | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.awsSecretAccessKey }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.secrets.awsSecretAccessKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.awsSessionToken }}
+  AWS_SESSION_TOKEN: {{ .Values.secrets.awsSessionToken | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.secrets.awsBearerTokenBedrock }}
+  AWS_BEARER_TOKEN_BEDROCK: {{ .Values.secrets.awsBearerTokenBedrock | b64enc | quote }}
+  {{- end }}
+  {{- end }}
+
+  # Optional: Context7 API key for library documentation MCP server
+  {{- if .Values.secrets.context7ApiKey }}
+  CONTEXT7_API_KEY: {{ .Values.secrets.context7ApiKey | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/github-app-playground/templates/service.yaml
+++ b/charts/github-app-playground/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      # Reference the named port from the Deployment so app.port and service stay in sync
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "github-app-playground.selectorLabels" . | nindent 4 }}

--- a/charts/github-app-playground/templates/serviceaccount.yaml
+++ b/charts/github-app-playground/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "github-app-playground.serviceAccountName" . }}
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -1,0 +1,238 @@
+# Default values for github-app-playground.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
+image:
+  repository: chrisleekr/github-app-playground
+  # This sets the pull policy for images.
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+imagePullSecrets: []
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The app does not require Kubernetes RBAC access, so API credentials should not be auto-mounted
+  automount: false
+  # Annotations to add to the service account (e.g. for IRSA on EKS)
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# This is for setting Kubernetes Annotations to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+podAnnotations: {}
+# This is for setting Kubernetes Labels to a Pod.
+# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+podLabels: {}
+
+podSecurityContext:
+  fsGroup: 1000
+  runAsUser: 1000
+  runAsNonRoot: true
+
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  # Must be false: the Node.js runtime writes to paths outside the workspace volume
+  # (e.g. npm cache, OS temp files). CLONE_BASE_DIR itself is on the mounted PVC.
+  readOnlyRootFilesystem: false
+  runAsNonRoot: true
+  runAsUser: 1000
+
+# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
+service:
+  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+  type: ClusterIP
+  # External service port
+  port: 80
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: github-app.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: github-app-tls
+  #    hosts:
+  #      - github-app.local
+
+# Resource recommendations are based on MAX_CONCURRENT_REQUESTS (default 3) * ~512Mi per request.
+# Adjust limits based on your actual concurrency setting.
+# For more information checkout: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+resources:
+  limits:
+    cpu: 2000m
+    memory: 2Gi
+  requests:
+    cpu: 500m
+    memory: 512Mi
+
+# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  httpGet:
+    path: /healthz
+    # Named port reference keeps probes in sync with app.port automatically
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+  successThreshold: 1
+
+readinessProbe:
+  httpGet:
+    path: /readyz
+    # Named port reference keeps probes in sync with app.port automatically
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+  successThreshold: 1
+
+# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
+# Note: autoscaling is disabled by default because the bot handles stateful repo clone workspaces
+# that are bound to a specific pod. Enable only if using a shared PVC (ReadWriteMany).
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 80
+
+# Pod Disruption Budget for more information checkout: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
+# Graceful shutdown period. The app waits up to 290s for in-flight requests before exiting.
+# Must be >= app shutdown timeout (290s). See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+terminationGracePeriodSeconds: 300
+
+# Workspace persistence for cloned repositories.
+# The app clones GitHub repos to CLONE_BASE_DIR for each bot request and cleans them up after.
+# A persistent volume is recommended over emptyDir to survive pod restarts mid-request.
+workspace:
+  persistence:
+    enabled: true
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+    # Set to use a pre-existing PVC instead of creating one
+    existingClaim: ""
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Extra environment variables injected directly into the container.
+# Use for values that don't fit the typed app/secrets sections (e.g. AWS_PROFILE for local SSO,
+# HTTP_PROXY, or any other ad-hoc env var).
+# See: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+extraEnv: []
+# - name: AWS_PROFILE
+#   value: my-sso-profile
+# - name: HTTP_PROXY
+#   value: http://proxy.example.com:3128
+
+# Application configuration (non-sensitive values — placed in a ConfigMap)
+# All values correspond to environment variables validated by src/config.ts
+app:
+  # HTTP server port — must match the containerPort named 'http' in the Deployment
+  port: 3000
+  # Node.js environment
+  nodeEnv: production
+  # Logging level: fatal | error | warn | info | debug | trace
+  logLevel: info
+  # Phrase that triggers the bot when mentioned in PR/issue comments
+  triggerPhrase: "@chrisleekr-bot"
+  # Maximum number of simultaneous Claude agent sessions
+  # Memory usage scales with this value (~512Mi per session)
+  maxConcurrentRequests: 3
+  # Timeout for each Claude agent run in milliseconds (default 10 minutes)
+  agentTimeoutMs: 600000
+  # Number of git commits to fetch when cloning a repo (shallow clone depth)
+  cloneDepth: 50
+  # Base directory for temporary repo clones (must match workspace.persistence mount)
+  cloneBaseDir: /tmp/bot-workspaces
+
+  # AI provider: "anthropic" (direct API) or "bedrock" (AWS Bedrock)
+  claudeProvider: anthropic
+
+  # Override only when using a custom image where claude-code is not at the default path.
+  # Leave empty to inherit the path baked into the Docker image via ENV.
+  # Default in official image: /usr/lib/node_modules/@anthropic-ai/claude-code/cli.js
+  claudeCodePath: ""
+
+  # AWS Bedrock provider settings (only required when claudeProvider=bedrock)
+  awsRegion: ""
+  # Claude model ID (e.g. us.anthropic.claude-opus-4-5-v1:0)
+  claudeModel: ""
+  # Optional custom Bedrock endpoint URL
+  anthropicBedrockBaseUrl: ""
+
+# Sensitive credentials (placed in a Kubernetes Secret)
+# Set existingSecret to use a pre-existing secret instead of creating one.
+# When using existingSecret, ensure it contains all the keys listed below.
+secrets:
+  # Name of an existing Secret. If set, the chart will NOT create a new Secret.
+  existingSecret: ""
+
+  # GitHub App credentials (required)
+  # Create a GitHub App at https://github.com/settings/apps
+  githubAppId: ""
+  # Multi-line PEM private key — newlines must be preserved
+  githubAppPrivateKey: ""
+  githubWebhookSecret: ""
+
+  # Anthropic API key (required when app.claudeProvider=anthropic)
+  anthropicApiKey: ""
+
+  # AWS credentials for Bedrock (required when app.claudeProvider=bedrock)
+  # Prefer IAM roles (IRSA/EC2 instance profile) over static keys in production
+  awsAccessKeyId: ""
+  awsSecretAccessKey: ""
+  awsSessionToken: ""
+  # AWS Bedrock bearer token (alternative to access key auth)
+  awsBearerTokenBedrock: ""
+
+  # Optional: Context7 API key for library documentation MCP server
+  context7ApiKey: ""

--- a/charts/n8n/templates/secret.yaml
+++ b/charts/n8n/templates/secret.yaml
@@ -1,0 +1,20 @@
+{{- if or .Values.encryption.key (and (eq .Values.database.type "postgres") .Values.database.postgres.external.enabled .Values.database.postgres.external.password) (and .Values.redis.enabled .Values.redis.external.enabled .Values.redis.external.password) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "n8n.fullname" . }}-secrets
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.encryption.key }}
+  encryptionKey: {{ .Values.encryption.key | b64enc | quote }}
+  {{- end }}
+  # If database type is postgres and external is enabled, create a secret for the postgres password
+  {{- if and (eq .Values.database.type "postgres") .Values.database.postgres.external.enabled .Values.database.postgres.external.password }}
+  externalDatabasePassword: {{ .Values.database.postgres.external.password | b64enc | quote }}
+  {{- end }}
+  {{- if and .Values.redis.enabled .Values.redis.external.enabled .Values.redis.external.password }}
+  redisPassword: {{ .Values.redis.external.password | b64enc | quote }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary

Introduces a new Helm chart for the `github-app-playground` GitHub App bot (responds to bot mentions on PRs/issues, uses Claude Agent SDK with MCP servers). Also adds a missing Secret template to the existing `n8n` chart and wires up GitLab CI pipelines for both.

## Changes

### New chart: `charts/github-app-playground/`

- **`Chart.yaml`** — Chart v0.1.0, requires Kubernetes ≥ 1.31.0, `appVersion: 1.0.0`
- **`values.yaml`** — Full default values with typed sections:
  - `app.*` — non-sensitive config (port, log level, trigger phrase, concurrency, clone settings, AI provider, model)
  - `secrets.*` — sensitive credentials (GitHub App ID/key/webhook, Anthropic API key, AWS Bedrock keys, Context7 key); supports `existingSecret` to reference a pre-existing Secret
  - `workspace.persistence` — PVC for cloned repo workspaces (10Gi RWO, `helm.sh/resource-policy: keep`)
  - `autoscaling`, `podDisruptionBudget`, `resources`, `livenessProbe`/`readinessProbe`, `terminationGracePeriodSeconds`
- **`templates/configmap.yaml`** — Non-sensitive env vars sourced into the container via `envFrom`; Bedrock-specific vars (`AWS_REGION`, `CLAUDE_MODEL`, `ANTHROPIC_BEDROCK_BASE_URL`) rendered only when `claudeProvider=bedrock`
- **`templates/secret.yaml`** — Sensitive credentials; Anthropic key emitted only for `anthropic` provider; AWS keys emitted only for `bedrock` provider and only when non-empty (avoids interfering with AWS SDK credential chain / IRSA); skipped entirely when `existingSecret` is set
- **`templates/deployment.yaml`** — Sources both ConfigMap and Secret via `envFrom`; mounts workspace PVC at `app.cloneBaseDir`; uses named port `http` for probes; sets `terminationGracePeriodSeconds` aligned with app's 290s shutdown timeout
- **`templates/pvc.yaml`** — Creates workspace PVC only when persistence is enabled and no `existingClaim` is set; `helm.sh/resource-policy: keep` prevents data loss on `helm uninstall`
- **`templates/pdb.yaml`** — PodDisruptionBudget with compile-time validation that `minAvailable` and `maxUnavailable` are mutually exclusive
- **`templates/hpa.yaml`** — HorizontalPodAutoscaler (`autoscaling/v2`); CPU and memory metrics rendered conditionally; disabled by default (stateful workspace per pod)
- **`templates/service.yaml`**, **`templates/serviceaccount.yaml`**, **`templates/ingress.yaml`**, **`templates/_helpers.tpl`**, **`templates/NOTES.txt`** — Standard chart scaffolding

### New: `charts/n8n/templates/secret.yaml`

Adds a conditional Kubernetes Secret for the `n8n` chart covering encryption key, external Postgres password, and external Redis password. The Secret is only created when at least one of those values is set.

### New CI: `.gitlab/ci/helm-github-app-playground.yml`

- **`test-github-app-playground-helm`** — Runs `helm template` (default + Bedrock path) and `helm lint` on changes to the chart; uploads rendered template as an artifact
- **`publish-github-app-playground-helm-dev`** — Publishes a dev-tagged version (`{version}-dev-{sha}`) to the GitLab Helm registry on any branch with chart changes
- Production bump/publish jobs are stubbed out as comments pending release workflow decision

### Updated: `.gitlab-ci.yml`

Adds `include` entry for the new `helm-github-app-playground.yml` CI file.

## Flow Diagram

```mermaid
flowchart TD
    subgraph Before
        B1[No github-app-playground chart]
        B2[n8n chart — no Secret template]
        B3[.gitlab-ci.yml — no github-app-playground CI]
    end

    subgraph After
        A1[charts/github-app-playground/]
        A1 --> A2[ConfigMap — non-sensitive app config]
        A1 --> A3[Secret — GitHub App + AI credentials]
        A1 --> A4[Deployment — envFrom ConfigMap + Secret\nworkspace PVC mount]
        A1 --> A5[PVC — 10Gi workspace with keep policy]
        A1 --> A6[PDB — optional, mutually exclusive guard]
        A1 --> A7[HPA — optional, disabled by default]
        A8[n8n chart — Secret for encryption/DB/Redis]
        A9[.gitlab-ci.yml — includes github-app-playground CI]
        A9 --> A10[Lint + template test job]
        A9 --> A11[Dev publish job]
    end
```