### PR TITLE
fix(ci): fix release pipeline failure due to missing chart version bumps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: Lint Charts
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.8.0
+
+      - name: Run chart-testing (lint)
+        # check-version-increment in ct.yaml enforces Chart.yaml version bump
+        # for any chart whose files have changed since the target branch
+        run: ct lint --config ct.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,11 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.7.0
-
-      - name: Run chart-testing (lint)
-        run: ct lint --config ct.yaml
-
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
+        with:
+          # Prevent pipeline failure when a release tag already exists
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_GENERATE_RELEASE_NOTES: true

--- a/charts/ip-lookup/Chart.yaml
+++ b/charts/ip-lookup/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/mcp-server-boilerplate/Chart.yaml
+++ b/charts/mcp-server-boilerplate/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/woodle-map/Chart.yaml
+++ b/charts/woodle-map/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/ct.yaml
+++ b/ct.yaml
@@ -2,3 +2,5 @@ remote: origin
 target-branch: main
 chart-dirs:
   - charts
+# Fail if a changed chart's version has not been incremented
+check-version-increment: true


### PR DESCRIPTION
## Summary

The release pipeline failed with a `422 already_exists` error because four charts (`ip-lookup`, `mcp-server-boilerplate`, `n8n`, `woodle-map`) had their files modified in a previous commit without bumping their `Chart.yaml` versions. When the next release CI ran, `chart-releaser` tried to re-publish those already-existing versions and failed.

This PR fixes the immediate breakage, adds a defensive guard to prevent future pipeline crashes, and introduces a PR-time lint gate to enforce version bumps before merge.

## Before

```mermaid
flowchart TD
    A["PR merged directly to main\nno lint check"] --> B["release.yml triggered"]
    B --> C["ct lint — no-op\ncompares main to main\n~17s wasted"]
    C --> D["chart-releaser"]
    D --> E["❌ 422 already_exists\nif chart version unchanged"]
```

## After

```mermaid
flowchart TD
    A["PR opened"] --> B["lint.yml triggered on PR\nct lint with check-version-increment\n❌ blocks if version not bumped"]
    B --> C["PR merged to main"]
    C --> D["release.yml triggered"]
    D --> E["chart-releaser\nwith skip_existing: true"]
    E --> F["✅ skips existing tags\nnew versions published cleanly"]
```

## Changes

### Bug fix — chart version bumps
These versions were modified in commit `26e7642` (security posture improvements) but never versioned, causing the `chart-releaser` to attempt publishing already-released tags:

- `charts/ip-lookup/Chart.yaml`: `0.1.5` → `0.1.6`
- `charts/mcp-server-boilerplate/Chart.yaml`: `0.0.1` → `0.0.2`
- `charts/n8n/Chart.yaml`: `0.0.1` → `0.0.2`
- `charts/woodle-map/Chart.yaml`: `0.0.1` → `0.0.2`

### Defensive guard — `release.yml`
- Added `skip_existing: true` to `helm/chart-releaser-action` so the pipeline   gracefully skips already-released chart versions instead of failing with a `422`
- Removed the `Set up chart-testing` + `ct lint` steps — these were a confirmed   no-op on the `main` branch (empty diff from `git merge-base origin/main HEAD`)   and only added ~17s of unnecessary overhead

### PR-time enforcement — `ct.yaml` + new `lint.yml`
- Added `check-version-increment: true` to `ct.yaml` — `ct lint` now fails if a   changed chart's `Chart.yaml` version has not been incremented
- Added `.github/workflows/lint.yml` — runs `ct lint` on every PR targeting `main`,   catching missing version bumps before merge rather than at release time
- Uses `helm/chart-testing-action@v2.8.0` (latest, vs `v2.7.0` previously used)