### PR TITLE
feat(github-app-playground): wire Phase 2/3 runtime into Helm chart

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,3 +23,39 @@ jobs:
         # check-version-increment in ct.yaml enforces Chart.yaml version bump
         # for any chart whose files have changed since the target branch
         run: ct lint --config ct.yaml
+
+      - name: Render github-app-playground feature matrix
+        # Exercises every conditional branch in the chart so a template error
+        # in any mode surfaces on the PR, not after publish. Uses only static,
+        # literal --set flags — no untrusted input from github.* contexts.
+        run: |
+          chart=charts/github-app-playground
+          set -euo pipefail
+          # 1. Phase 1 (inline) — current production topology.
+          helm template "$chart" > /dev/null
+          # 2. Bedrock provider path.
+          helm template "$chart" \
+            --set config.provider=bedrock \
+            --set config.awsRegion=us-east-1 \
+            --set config.model=us.anthropic.claude-sonnet-4-5-v1:0 > /dev/null
+          # 3. Phase 4 with in-chart Postgres + Valkey + RBAC + shared runner stub.
+          helm template "$chart" \
+            --set postgres.enabled=true --set valkey.enabled=true \
+            --set rbac.create=true --set sharedRunner.enabled=true \
+            --set config.agentJobMode=auto > /dev/null
+          # 4. Phase 4 with external Postgres + Valkey (literal password path).
+          helm template "$chart" \
+            --set postgres.external.enabled=true \
+            --set postgres.external.host=pg \
+            --set postgres.external.username=u \
+            --set postgres.external.database=d \
+            --set postgres.external.password=p \
+            --set valkey.external.enabled=true \
+            --set valkey.external.host=r \
+            --set valkey.external.auth.password=p \
+            --set config.agentJobMode=auto > /dev/null
+          # 5. User-supplied URLs (neither in-chart nor external enabled).
+          helm template "$chart" \
+            --set config.databaseUrl=postgres://u:p@h/d \
+            --set config.valkeyUrl=redis://h:6379 \
+            --set config.agentJobMode=daemon > /dev/null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,35 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Verify chart versions are not already released
+        # Fail loudly if any chart's Chart.yaml version already has a matching
+        # <chart-name>-<version> git tag. chart-releaser's skip_existing would
+        # otherwise silently skip — which hides accidental no-op releases.
+        # Inputs are files + git tags only; no github.* context data is used.
+        run: |
+          set -euo pipefail
+          fail=0
+          for chart_dir in charts/*/; do
+            if [ ! -f "${chart_dir}Chart.yaml" ]; then
+              continue
+            fi
+            name=$(yq e '.name' "${chart_dir}Chart.yaml")
+            version=$(yq e '.version' "${chart_dir}Chart.yaml")
+            tag="${name}-${version}"
+            if git rev-parse "refs/tags/${tag}" >/dev/null 2>&1; then
+              echo "::error file=${chart_dir}Chart.yaml::tag ${tag} already exists - bump version before merging"
+              fail=1
+            fi
+          done
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         with:
-          # Prevent pipeline failure when a release tag already exists
+          # Safety net: if a chart escapes the gate above, still don't fail the
+          # job - but the gate should have caught it first.
           skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.0.0"
+appVersion: "1.1.0"
 
 kubeVersion: ">= 1.31.0"
 

--- a/charts/github-app-playground/templates/NOTES.txt
+++ b/charts/github-app-playground/templates/NOTES.txt
@@ -44,3 +44,20 @@
 5. Tail dispatch / triage decisions:
    kubectl --namespace {{ .Release.Namespace }} logs -f deploy/{{ include "github-app-playground.fullname" . }} \
      | jq 'select(.msg | test("dispatch decision|triage"))'
+
+UPGRADING from chart 0.1.x:
+   Chart 0.2.0 restructured values.yaml. The old `app:` and `secrets:` top-level
+   blocks are gone; every application knob now lives under `config:` (a flat 1:1
+   mirror of the app image's src/config.ts Zod schema). Renames you must apply
+   to your override values before `helm upgrade`:
+     app.port                 -> config.port
+     app.cloneBaseDir         -> config.cloneBaseDir
+     app.triggerPhrase        -> config.triggerPhrase
+     secrets.existingSecret   -> config.existingSecret
+     secrets.appId            -> config.appId
+     secrets.privateKey       -> config.privateKey
+     secrets.webhookSecret    -> config.webhookSecret
+     secrets.anthropicApiKey  -> config.anthropicApiKey
+     secrets.context7ApiKey   -> config.context7ApiKey
+   Upgrading without renaming will produce a Deployment that mounts no
+   credentials and crashes at startup.

--- a/charts/github-app-playground/templates/NOTES.txt
+++ b/charts/github-app-playground/templates/NOTES.txt
@@ -11,18 +11,36 @@
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "github-app-playground.fullname" . }}'
+           Watch with: kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "github-app-playground.fullname" . }}
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "github-app-playground.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "github-app-playground.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:{{ .Values.config.port }}
+  echo "Visit http://127.0.0.1:8080"
 {{- end }}
 
-2. Configure your GitHub App webhook to point to:
+2. Configure your GitHub App webhook to POST to:
    <your-ingress-host>/api/github/webhooks
 
-3. Verify the bot is healthy:
+3. Current dispatch mode: {{ .Values.config.agentJobMode }}
+{{- if eq .Values.config.agentJobMode "inline" }}
+   Runs agent in-process. No data-layer infra required.
+{{- else }}
+   Requires DATABASE_URL, VALKEY_URL, DAEMON_AUTH_TOKEN (auto-wired when
+   postgres.enabled / valkey.enabled, or auto-generated for the token).
+{{- if or (eq .Values.config.agentJobMode "isolated-job") (eq .Values.config.agentJobMode "auto") }}
+   isolated-job spawning also requires rbac.create=true.
+{{- end }}
+{{- if or (eq .Values.config.agentJobMode "shared-runner") (eq .Values.config.agentJobMode "auto") }}
+   shared-runner also requires config.internalRunnerUrl and the target
+   runner to expose POST /internal/run (NOTE: not yet shipped in the app image).
+{{- end }}
+{{- end }}
+
+4. Verify the bot is healthy:
    kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ include "github-app-playground.name" . }}"
+
+5. Tail dispatch / triage decisions:
+   kubectl --namespace {{ .Release.Namespace }} logs -f deploy/{{ include "github-app-playground.fullname" . }} \
+     | jq 'select(.msg | test("dispatch decision|triage"))'

--- a/charts/github-app-playground/templates/_helpers.tpl
+++ b/charts/github-app-playground/templates/_helpers.tpl
@@ -127,23 +127,41 @@ Falls back to `randAlphaNum 64` when no existing Secret holds the key.
 
 {{/*
 Resolved Postgres password (in-chart Postgres).
-Preference: .Values.postgres.auth.existingSecret → stable token generated value.
-When postgres.auth.existingSecret is set, this helper is not consulted.
+Reads from whichever Secret the StatefulSet mounts:
+  - postgres.auth.existingSecret  → that Secret's POSTGRES_PASSWORD key.
+  - otherwise                     → chart-managed Secret, stable across upgrades.
+This keeps DATABASE_URL in sync with the password the Postgres pod actually uses.
 */}}
 {{- define "github-app-playground.postgresPassword" -}}
+{{- if .Values.postgres.auth.existingSecret -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace .Values.postgres.auth.existingSecret -}}
+{{- if and $existing (index $existing.data "POSTGRES_PASSWORD") -}}
+{{- index $existing.data "POSTGRES_PASSWORD" | b64dec -}}
+{{- end -}}
+{{- else -}}
 {{- include "github-app-playground.stableToken" (dict
     "key" "POSTGRES_PASSWORD"
     "secretName" (printf "%s-postgres-secret" (include "github-app-playground.fullname" .))
     "override" ""
     "root" .) -}}
+{{- end -}}
 {{- end }}
 
 {{/*
 Resolved Valkey password (in-chart Valkey). Matches mcp-server-boilerplate shape
 where the Secret key is lowercase `password`.
+Reads from whichever Secret the Deployment mounts:
+  - valkey.auth.existingSecret    → that Secret's `password` key.
+  - valkey.auth.password literal  → use verbatim.
+  - otherwise                     → chart-managed Secret, stable across upgrades.
 */}}
 {{- define "github-app-playground.valkeyPassword" -}}
-{{- if .Values.valkey.auth.password -}}
+{{- if .Values.valkey.auth.existingSecret -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace .Values.valkey.auth.existingSecret -}}
+{{- if and $existing (index $existing.data "password") -}}
+{{- index $existing.data "password" | b64dec -}}
+{{- end -}}
+{{- else if .Values.valkey.auth.password -}}
 {{- .Values.valkey.auth.password -}}
 {{- else -}}
 {{- include "github-app-playground.stableToken" (dict

--- a/charts/github-app-playground/templates/_helpers.tpl
+++ b/charts/github-app-playground/templates/_helpers.tpl
@@ -62,20 +62,19 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Return the name of the Secret to use for app credentials.
-Uses existingSecret if provided, otherwise uses the chart-managed secret name.
+Name of the Secret holding app credentials. Uses config.existingSecret when set,
+otherwise the chart-managed name <fullname>-secret.
 */}}
 {{- define "github-app-playground.secretName" -}}
-{{- if .Values.secrets.existingSecret }}
-{{- .Values.secrets.existingSecret }}
+{{- if .Values.config.existingSecret }}
+{{- .Values.config.existingSecret }}
 {{- else }}
 {{- printf "%s-secret" (include "github-app-playground.fullname" .) }}
 {{- end }}
 {{- end }}
 
 {{/*
-Return the name of the workspace PVC to use.
-Uses existingClaim if provided, otherwise uses the chart-managed PVC name.
+Workspace PVC name. Uses existingClaim when set, otherwise <fullname>-workspace.
 */}}
 {{- define "github-app-playground.workspacePVCName" -}}
 {{- if .Values.workspace.persistence.existingClaim }}
@@ -83,4 +82,149 @@ Uses existingClaim if provided, otherwise uses the chart-managed PVC name.
 {{- else }}
 {{- printf "%s-workspace" (include "github-app-playground.fullname" .) }}
 {{- end }}
+{{- end }}
+
+{{/*
+Postgres / Valkey Secret names (chart-managed, for the stateful sidecars).
+*/}}
+{{- define "github-app-playground.postgresSecretName" -}}
+{{- if .Values.postgres.auth.existingSecret }}
+{{- .Values.postgres.auth.existingSecret }}
+{{- else }}
+{{- printf "%s-postgres-secret" (include "github-app-playground.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{- define "github-app-playground.valkeySecretName" -}}
+{{- if .Values.valkey.auth.existingSecret }}
+{{- .Values.valkey.auth.existingSecret }}
+{{- else }}
+{{- printf "%s-valkey-secret" (include "github-app-playground.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Generate a value that persists across upgrades via `lookup`.
+Args (dict): key (secret data key, e.g. DAEMON_AUTH_TOKEN),
+             secretName (which Secret to inspect),
+             override (optional literal value that short-circuits generation),
+             root (.).
+Falls back to `randAlphaNum 64` when no existing Secret holds the key.
+*/}}
+{{- define "github-app-playground.stableToken" -}}
+{{- $override := .override -}}
+{{- if $override -}}
+{{- $override -}}
+{{- else -}}
+{{- $existing := lookup "v1" "Secret" .root.Release.Namespace .secretName -}}
+{{- if and $existing (index $existing.data .key) -}}
+{{- index $existing.data .key | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 64 -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolved Postgres password (in-chart Postgres).
+Preference: .Values.postgres.auth.existingSecret → stable token generated value.
+When postgres.auth.existingSecret is set, this helper is not consulted.
+*/}}
+{{- define "github-app-playground.postgresPassword" -}}
+{{- include "github-app-playground.stableToken" (dict
+    "key" "POSTGRES_PASSWORD"
+    "secretName" (printf "%s-postgres-secret" (include "github-app-playground.fullname" .))
+    "override" ""
+    "root" .) -}}
+{{- end }}
+
+{{/*
+Resolved Valkey password (in-chart Valkey). Matches mcp-server-boilerplate shape
+where the Secret key is lowercase `password`.
+*/}}
+{{- define "github-app-playground.valkeyPassword" -}}
+{{- if .Values.valkey.auth.password -}}
+{{- .Values.valkey.auth.password -}}
+{{- else -}}
+{{- include "github-app-playground.stableToken" (dict
+    "key" "password"
+    "secretName" (printf "%s-valkey-secret" (include "github-app-playground.fullname" .))
+    "override" ""
+    "root" .) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolved external-Postgres password (postgres.external.enabled=true path).
+Order: external.existingSecret (read at render time) → external.password literal.
+When external.existingSecret is set and exists, return its password key; else "".
+Callers should only use when composing the DATABASE_URL from external fields.
+*/}}
+{{- define "github-app-playground.externalPostgresPassword" -}}
+{{- if .Values.postgres.external.existingSecret -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace .Values.postgres.external.existingSecret -}}
+{{- if and $existing (index $existing.data .Values.postgres.external.existingSecretPasswordKey) -}}
+{{- index $existing.data .Values.postgres.external.existingSecretPasswordKey | b64dec -}}
+{{- end -}}
+{{- else -}}
+{{- .Values.postgres.external.password -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolved external-Valkey password. Mirrors externalPostgresPassword.
+*/}}
+{{- define "github-app-playground.externalValkeyPassword" -}}
+{{- if .Values.valkey.external.auth.existingSecret -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace .Values.valkey.external.auth.existingSecret -}}
+{{- if and $existing (index $existing.data .Values.valkey.external.auth.existingSecretPasswordKey) -}}
+{{- index $existing.data .Values.valkey.external.auth.existingSecretPasswordKey | b64dec -}}
+{{- end -}}
+{{- else -}}
+{{- .Values.valkey.external.auth.password -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Composed DATABASE_URL. Resolution order (stops at first match):
+  1. config.databaseUrl (literal) → use verbatim.
+  2. postgres.enabled=true        → postgresql://u:p@<fullname>-postgres:port/db?sslmode=disable
+  3. postgres.external.enabled=true → postgresql://u:p@host:port/db?sslmode=<sslmode>
+  4. nothing                      → empty string.
+Consumers: template that emits it skips writing the key when empty.
+*/}}
+{{- define "github-app-playground.databaseUrl" -}}
+{{- if .Values.config.databaseUrl -}}
+{{- .Values.config.databaseUrl -}}
+{{- else if .Values.postgres.enabled -}}
+{{- $pw := include "github-app-playground.postgresPassword" . -}}
+{{- printf "postgresql://%s:%s@%s-postgres:%d/%s?sslmode=disable" .Values.postgres.auth.username $pw (include "github-app-playground.fullname" .) (int .Values.postgres.service.port) .Values.postgres.auth.database -}}
+{{- else if .Values.postgres.external.enabled -}}
+{{- $pw := include "github-app-playground.externalPostgresPassword" . -}}
+{{- printf "postgresql://%s:%s@%s:%d/%s?sslmode=%s" .Values.postgres.external.username $pw .Values.postgres.external.host (int .Values.postgres.external.port) .Values.postgres.external.database .Values.postgres.external.sslmode -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Composed VALKEY_URL. Same resolution order as databaseUrl.
+*/}}
+{{- define "github-app-playground.valkeyUrl" -}}
+{{- if .Values.config.valkeyUrl -}}
+{{- .Values.config.valkeyUrl -}}
+{{- else if .Values.valkey.enabled -}}
+{{- $host := printf "%s-valkey" (include "github-app-playground.fullname" .) -}}
+{{- if .Values.valkey.auth.enabled -}}
+{{- $pw := include "github-app-playground.valkeyPassword" . -}}
+{{- printf "redis://default:%s@%s:%d/0" $pw $host (int .Values.valkey.service.port) -}}
+{{- else -}}
+{{- printf "redis://%s:%d/0" $host (int .Values.valkey.service.port) -}}
+{{- end -}}
+{{- else if .Values.valkey.external.enabled -}}
+{{- if .Values.valkey.external.auth.enabled -}}
+{{- $pw := include "github-app-playground.externalValkeyPassword" . -}}
+{{- printf "redis://default:%s@%s:%d/%d" $pw .Values.valkey.external.host (int .Values.valkey.external.port) (int .Values.valkey.external.database) -}}
+{{- else -}}
+{{- printf "redis://%s:%d/%d" .Values.valkey.external.host (int .Values.valkey.external.port) (int .Values.valkey.external.database) -}}
+{{- end -}}
+{{- end -}}
 {{- end }}

--- a/charts/github-app-playground/templates/configmap.yaml
+++ b/charts/github-app-playground/templates/configmap.yaml
@@ -5,42 +5,92 @@ metadata:
   labels:
     {{- include "github-app-playground.labels" . | nindent 4 }}
 data:
-  # HTTP server configuration
-  PORT: {{ .Values.app.port | quote }}
-  NODE_ENV: {{ .Values.app.nodeEnv | quote }}
-  LOG_LEVEL: {{ .Values.app.logLevel | quote }}
+  # Non-secret env vars. Each key is gated by `ne <val> ""` so empty values become
+  # "not set" at the pod level, letting src/config.ts Zod apply its own defaults or
+  # surface its own "required when X" errors rather than masking them with empty strings.
+  {{- $c := .Values.config }}
 
-  # Bot trigger configuration
-  TRIGGER_PHRASE: {{ .Values.app.triggerPhrase | quote }}
-
-  # Concurrency and timeout settings
-  MAX_CONCURRENT_REQUESTS: {{ .Values.app.maxConcurrentRequests | quote }}
-  AGENT_TIMEOUT_MS: {{ .Values.app.agentTimeoutMs | quote }}
-
-  # Git clone settings
-  CLONE_DEPTH: {{ .Values.app.cloneDepth | quote }}
-  # Must match the mountPath of the workspace volume
-  CLONE_BASE_DIR: {{ .Values.app.cloneBaseDir | quote }}
-
-  # AI provider: "anthropic" or "bedrock"
-  CLAUDE_PROVIDER: {{ .Values.app.claudeProvider | quote }}
-
-  # AWS Bedrock provider settings (only used when CLAUDE_PROVIDER=bedrock)
-  {{- if eq .Values.app.claudeProvider "bedrock" }}
-  AWS_REGION: {{ .Values.app.awsRegion | quote }}
-  # Only set when non-empty: process.env["CLAUDE_MODEL"]="" fails z.string().min(1) with a
-  # confusing error; leaving it unset lets superRefine emit the clear message instead.
-  {{- if .Values.app.claudeModel }}
-  CLAUDE_MODEL: {{ .Values.app.claudeModel | quote }}
+  # === Webhook server ===
+  PORT: {{ $c.port | quote }}
+  NODE_ENV: {{ $c.nodeEnv | quote }}
+  LOG_LEVEL: {{ $c.logLevel | quote }}
+  TRIGGER_PHRASE: {{ $c.triggerPhrase | quote }}
+  MAX_CONCURRENT_REQUESTS: {{ $c.maxConcurrentRequests | quote }}
+  AGENT_TIMEOUT_MS: {{ $c.agentTimeoutMs | quote }}
+  {{- if ne ($c.agentMaxTurns | toString) "" }}
+  AGENT_MAX_TURNS: {{ $c.agentMaxTurns | quote }}
   {{- end }}
-  # Only set when non-empty: an empty URL string may be misinterpreted by the Claude SDK
-  {{- if .Values.app.anthropicBedrockBaseUrl }}
-  ANTHROPIC_BEDROCK_BASE_URL: {{ .Values.app.anthropicBedrockBaseUrl | quote }}
+  CLONE_DEPTH: {{ $c.cloneDepth | quote }}
+  CLONE_BASE_DIR: {{ $c.cloneBaseDir | quote }}
+  {{- if $c.claudeCodePath }}
+  CLAUDE_CODE_PATH: {{ $c.claudeCodePath | quote }}
   {{- end }}
+  {{- if $c.allowedOwners }}
+  ALLOWED_OWNERS: {{ $c.allowedOwners | quote }}
   {{- end }}
 
-  # Override the Claude Code CLI path when using a custom image.
-  # Leave unset to rely on the CLAUDE_CODE_PATH baked into the Docker image ENV.
-  {{- if .Values.app.claudeCodePath }}
-  CLAUDE_CODE_PATH: {{ .Values.app.claudeCodePath | quote }}
+  # === AI provider ===
+  CLAUDE_PROVIDER: {{ $c.provider | quote }}
+  {{- if $c.model }}
+  CLAUDE_MODEL: {{ $c.model | quote }}
   {{- end }}
+  {{- if $c.awsRegion }}
+  AWS_REGION: {{ $c.awsRegion | quote }}
+  {{- end }}
+  {{- if $c.awsProfile }}
+  AWS_PROFILE: {{ $c.awsProfile | quote }}
+  {{- end }}
+  {{- if $c.anthropicBedrockBaseUrl }}
+  ANTHROPIC_BEDROCK_BASE_URL: {{ $c.anthropicBedrockBaseUrl | quote }}
+  {{- end }}
+
+  # === Dispatch cascade ===
+  AGENT_JOB_MODE: {{ $c.agentJobMode | quote }}
+  DEFAULT_DISPATCH_TARGET: {{ $c.defaultDispatchTarget | quote }}
+
+  # === isolated-job spawner (read when agentJobMode is isolated-job or auto) ===
+  {{- if $c.jobNamespace }}
+  JOB_NAMESPACE: {{ $c.jobNamespace | quote }}
+  {{- end }}
+  {{- if $c.jobImage }}
+  JOB_IMAGE: {{ $c.jobImage | quote }}
+  {{- end }}
+  JOB_TTL_SECONDS: {{ $c.jobTtlSeconds | quote }}
+  JOB_ACTIVE_DEADLINE_SECONDS: {{ $c.jobActiveDeadlineSeconds | quote }}
+  JOB_WATCH_POLL_INTERVAL_MS: {{ $c.jobWatchPollIntervalMs | quote }}
+  JOB_MAX_COST_USD: {{ $c.jobMaxCostUsd | quote }}
+  JOB_MAX_RETRIES: {{ $c.jobMaxRetries | quote }}
+  MAX_CONCURRENT_ISOLATED_JOBS: {{ $c.maxConcurrentIsolatedJobs | quote }}
+  PENDING_ISOLATED_JOB_QUEUE_MAX: {{ $c.pendingIsolatedJobQueueMax | quote }}
+
+  # === Shared runner client (read when agentJobMode is shared-runner or auto) ===
+  {{- if $c.internalRunnerUrl }}
+  INTERNAL_RUNNER_URL: {{ $c.internalRunnerUrl | quote }}
+  {{- end }}
+
+  # === Orchestrator / daemon ===
+  WS_PORT: {{ $c.wsPort | quote }}
+  {{- if $c.orchestratorUrl }}
+  ORCHESTRATOR_URL: {{ $c.orchestratorUrl | quote }}
+  {{- end }}
+  HEARTBEAT_INTERVAL_MS: {{ $c.heartbeatIntervalMs | quote }}
+  HEARTBEAT_TIMEOUT_MS: {{ $c.heartbeatTimeoutMs | quote }}
+  STALE_EXECUTION_THRESHOLD_MS: {{ $c.staleExecutionThresholdMs | quote }}
+  DAEMON_DRAIN_TIMEOUT_MS: {{ $c.daemonDrainTimeoutMs | quote }}
+  OFFER_TIMEOUT_MS: {{ $c.offerTimeoutMs | quote }}
+  DAEMON_UPDATE_STRATEGY: {{ $c.daemonUpdateStrategy | quote }}
+  DAEMON_UPDATE_DELAY_MS: {{ $c.daemonUpdateDelayMs | quote }}
+  DAEMON_EPHEMERAL: {{ $c.daemonEphemeral | quote }}
+  DAEMON_MEMORY_FLOOR_MB: {{ $c.daemonMemoryFloorMb | quote }}
+  DAEMON_DISK_FLOOR_MB: {{ $c.daemonDiskFloorMb | quote }}
+
+  # === Triage (read when agentJobMode=auto) ===
+  TRIAGE_ENABLED: {{ $c.triageEnabled | quote }}
+  TRIAGE_MODEL: {{ $c.triageModel | quote }}
+  TRIAGE_CONFIDENCE_THRESHOLD: {{ $c.triageConfidenceThreshold | quote }}
+  TRIAGE_MAX_TOKENS: {{ $c.triageMaxTokens | quote }}
+  TRIAGE_TIMEOUT_MS: {{ $c.triageTimeoutMs | quote }}
+  TRIAGE_MAXTURNS_TRIVIAL: {{ $c.triageMaxTurnsTrivial | quote }}
+  TRIAGE_MAXTURNS_MODERATE: {{ $c.triageMaxTurnsModerate | quote }}
+  TRIAGE_MAXTURNS_COMPLEX: {{ $c.triageMaxTurnsComplex | quote }}
+  DEFAULT_MAXTURNS: {{ $c.defaultMaxTurns | quote }}

--- a/charts/github-app-playground/templates/configmap.yaml
+++ b/charts/github-app-playground/templates/configmap.yaml
@@ -5,35 +5,19 @@ metadata:
   labels:
     {{- include "github-app-playground.labels" . | nindent 4 }}
 data:
-  # Non-secret env vars. Each key is gated by `ne <val> ""` so empty values become
-  # "not set" at the pod level, letting src/config.ts Zod apply its own defaults or
-  # surface its own "required when X" errors rather than masking them with empty strings.
+  # Non-secret env vars. Each optional key is gated by `ne <val> ""` so empty
+  # values become "not set" at the pod level and src/config.ts Zod applies
+  # its own defaults or surfaces its own "required when X" errors.
+  # Field order mirrors the numbered groups in src/config.ts.
   {{- $c := .Values.config }}
 
-  # === Webhook server ===
-  PORT: {{ $c.port | quote }}
-  NODE_ENV: {{ $c.nodeEnv | quote }}
-  LOG_LEVEL: {{ $c.logLevel | quote }}
-  TRIGGER_PHRASE: {{ $c.triggerPhrase | quote }}
-  MAX_CONCURRENT_REQUESTS: {{ $c.maxConcurrentRequests | quote }}
-  AGENT_TIMEOUT_MS: {{ $c.agentTimeoutMs | quote }}
-  {{- if ne ($c.agentMaxTurns | toString) "" }}
-  AGENT_MAX_TURNS: {{ $c.agentMaxTurns | quote }}
-  {{- end }}
-  CLONE_DEPTH: {{ $c.cloneDepth | quote }}
-  CLONE_BASE_DIR: {{ $c.cloneBaseDir | quote }}
-  {{- if $c.claudeCodePath }}
-  CLAUDE_CODE_PATH: {{ $c.claudeCodePath | quote }}
-  {{- end }}
-  {{- if $c.allowedOwners }}
-  ALLOWED_OWNERS: {{ $c.allowedOwners | quote }}
-  {{- end }}
-
-  # === AI provider ===
+  # --- 2. AI provider selection ---
   CLAUDE_PROVIDER: {{ $c.provider | quote }}
   {{- if $c.model }}
   CLAUDE_MODEL: {{ $c.model | quote }}
   {{- end }}
+
+  # --- 4. AWS Bedrock credentials (non-secret subset) ---
   {{- if $c.awsRegion }}
   AWS_REGION: {{ $c.awsRegion | quote }}
   {{- end }}
@@ -44,32 +28,49 @@ data:
   ANTHROPIC_BEDROCK_BASE_URL: {{ $c.anthropicBedrockBaseUrl | quote }}
   {{- end }}
 
-  # === Dispatch cascade ===
+  # --- 5. App runtime / behaviour ---
+  CLONE_BASE_DIR: {{ $c.cloneBaseDir | quote }}
+  CLONE_DEPTH: {{ $c.cloneDepth | quote }}
+  TRIGGER_PHRASE: {{ $c.triggerPhrase | quote }}
+  PORT: {{ $c.port | quote }}
+  LOG_LEVEL: {{ $c.logLevel | quote }}
+  NODE_ENV: {{ $c.nodeEnv | quote }}
+  MAX_CONCURRENT_REQUESTS: {{ $c.maxConcurrentRequests | quote }}
+  AGENT_TIMEOUT_MS: {{ $c.agentTimeoutMs | quote }}
+  {{- if ne ($c.agentMaxTurns | toString) "" }}
+  AGENT_MAX_TURNS: {{ $c.agentMaxTurns | quote }}
+  {{- end }}
+  {{- if $c.claudeCodePath }}
+  CLAUDE_CODE_PATH: {{ $c.claudeCodePath | quote }}
+  {{- end }}
+  {{- if $c.allowedOwners }}
+  ALLOWED_OWNERS: {{ $c.allowedOwners | quote }}
+  {{- end }}
+
+  # --- 6. Dispatch mode ---
   AGENT_JOB_MODE: {{ $c.agentJobMode | quote }}
   DEFAULT_DISPATCH_TARGET: {{ $c.defaultDispatchTarget | quote }}
 
-  # === isolated-job spawner (read when agentJobMode is isolated-job or auto) ===
-  {{- if $c.jobNamespace }}
-  JOB_NAMESPACE: {{ $c.jobNamespace | quote }}
-  {{- end }}
-  {{- if $c.jobImage }}
-  JOB_IMAGE: {{ $c.jobImage | quote }}
-  {{- end }}
+  # --- 7. K8s Job spawner (isolated-job target) ---
+  # JOB_NAMESPACE falls back to the release namespace when the user leaves it empty,
+  # so isolated-job pods land next to the release by default.
+  JOB_NAMESPACE: {{ default .Release.Namespace $c.jobNamespace | quote }}
+  # JOB_IMAGE falls back to the webhook image so the spawned Pod runs the same build.
+  JOB_IMAGE: {{ default (printf "%s:%s" .Values.image.repository (.Values.image.tag | default .Chart.AppVersion)) $c.jobImage | quote }}
   JOB_TTL_SECONDS: {{ $c.jobTtlSeconds | quote }}
   JOB_ACTIVE_DEADLINE_SECONDS: {{ $c.jobActiveDeadlineSeconds | quote }}
   JOB_WATCH_POLL_INTERVAL_MS: {{ $c.jobWatchPollIntervalMs | quote }}
-  JOB_MAX_COST_USD: {{ $c.jobMaxCostUsd | quote }}
-  JOB_MAX_RETRIES: {{ $c.jobMaxRetries | quote }}
-  MAX_CONCURRENT_ISOLATED_JOBS: {{ $c.maxConcurrentIsolatedJobs | quote }}
-  PENDING_ISOLATED_JOB_QUEUE_MAX: {{ $c.pendingIsolatedJobQueueMax | quote }}
 
-  # === Shared runner client (read when agentJobMode is shared-runner or auto) ===
+  # --- 8. Shared-runner HTTP target ---
   {{- if $c.internalRunnerUrl }}
   INTERNAL_RUNNER_URL: {{ $c.internalRunnerUrl | quote }}
   {{- end }}
 
-  # === Orchestrator / daemon ===
+  # --- 10. Orchestrator ---
   WS_PORT: {{ $c.wsPort | quote }}
+  JOB_MAX_COST_USD: {{ $c.jobMaxCostUsd | quote }}
+
+  # --- 11. Daemon / Orchestrator WebSocket ---
   {{- if $c.orchestratorUrl }}
   ORCHESTRATOR_URL: {{ $c.orchestratorUrl | quote }}
   {{- end }}
@@ -77,6 +78,7 @@ data:
   HEARTBEAT_TIMEOUT_MS: {{ $c.heartbeatTimeoutMs | quote }}
   STALE_EXECUTION_THRESHOLD_MS: {{ $c.staleExecutionThresholdMs | quote }}
   DAEMON_DRAIN_TIMEOUT_MS: {{ $c.daemonDrainTimeoutMs | quote }}
+  JOB_MAX_RETRIES: {{ $c.jobMaxRetries | quote }}
   OFFER_TIMEOUT_MS: {{ $c.offerTimeoutMs | quote }}
   DAEMON_UPDATE_STRATEGY: {{ $c.daemonUpdateStrategy | quote }}
   DAEMON_UPDATE_DELAY_MS: {{ $c.daemonUpdateDelayMs | quote }}
@@ -84,13 +86,19 @@ data:
   DAEMON_MEMORY_FLOOR_MB: {{ $c.daemonMemoryFloorMb | quote }}
   DAEMON_DISK_FLOOR_MB: {{ $c.daemonDiskFloorMb | quote }}
 
-  # === Triage (read when agentJobMode=auto) ===
+  # --- 12. Triage pre-classifier ---
   TRIAGE_ENABLED: {{ $c.triageEnabled | quote }}
   TRIAGE_MODEL: {{ $c.triageModel | quote }}
   TRIAGE_CONFIDENCE_THRESHOLD: {{ $c.triageConfidenceThreshold | quote }}
   TRIAGE_MAX_TOKENS: {{ $c.triageMaxTokens | quote }}
   TRIAGE_TIMEOUT_MS: {{ $c.triageTimeoutMs | quote }}
+
+  # --- 13. Complexity → maxTurns mapping ---
   TRIAGE_MAXTURNS_TRIVIAL: {{ $c.triageMaxTurnsTrivial | quote }}
   TRIAGE_MAXTURNS_MODERATE: {{ $c.triageMaxTurnsModerate | quote }}
   TRIAGE_MAXTURNS_COMPLEX: {{ $c.triageMaxTurnsComplex | quote }}
   DEFAULT_MAXTURNS: {{ $c.defaultMaxTurns | quote }}
+
+  # --- 14. Isolated-job capacity back-pressure ---
+  MAX_CONCURRENT_ISOLATED_JOBS: {{ $c.maxConcurrentIsolatedJobs | quote }}
+  PENDING_ISOLATED_JOB_QUEUE_MAX: {{ $c.pendingIsolatedJobQueueMax | quote }}

--- a/charts/github-app-playground/templates/deployment.yaml
+++ b/charts/github-app-playground/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.app.port }}
+              containerPort: {{ .Values.config.port }}
               protocol: TCP
           envFrom:
             - configMapRef:
@@ -58,7 +58,7 @@ spec:
           volumeMounts:
             {{- if .Values.workspace.persistence.enabled }}
             - name: workspace
-              mountPath: {{ .Values.app.cloneBaseDir | quote }}
+              mountPath: {{ .Values.config.cloneBaseDir | quote }}
             {{- end }}
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}

--- a/charts/github-app-playground/templates/postgres-secret.yaml
+++ b/charts/github-app-playground/templates/postgres-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.postgres.enabled (not .Values.postgres.auth.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}-postgres-secret
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+type: Opaque
+data:
+  POSTGRES_PASSWORD: {{ include "github-app-playground.postgresPassword" . | b64enc | quote }}
+{{- end }}

--- a/charts/github-app-playground/templates/postgres-service.yaml
+++ b/charts/github-app-playground/templates/postgres-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}-postgres
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  type: {{ .Values.postgres.service.type }}
+  ports:
+    - port: {{ .Values.postgres.service.port }}
+      targetPort: postgres
+      protocol: TCP
+      name: postgres
+  selector:
+    {{- include "github-app-playground.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+{{- end }}

--- a/charts/github-app-playground/templates/postgres-statefulset.yaml
+++ b/charts/github-app-playground/templates/postgres-statefulset.yaml
@@ -1,0 +1,133 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}-postgres
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  replicas: 1
+  serviceName: {{ include "github-app-playground.fullname" . }}-postgres
+  selector:
+    matchLabels:
+      {{- include "github-app-playground.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        {{- include "github-app-playground.labels" . | nindent 8 }}
+        app.kubernetes.io/component: postgres
+    spec:
+      {{- with .Values.postgres.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: postgres
+          {{- with .Values.postgres.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
+          imagePullPolicy: {{ .Values.postgres.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.auth.username | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.auth.database | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "github-app-playground.postgresSecretName" . }}
+                  key: POSTGRES_PASSWORD
+            # pgvector/pgvector:pg17 respects PGDATA; use the subpath convention so
+            # the Postgres process owns a clean subdirectory under the PVC.
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          {{- with .Values.postgres.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgres.auth.username }}
+                - -d
+                - {{ .Values.postgres.auth.database }}
+                - -h
+                - 127.0.0.1
+                - -p
+                - "5432"
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgres.auth.username }}
+                - -d
+                - {{ .Values.postgres.auth.database }}
+                - -h
+                - 127.0.0.1
+                - -p
+                - "5432"
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+      {{- with .Values.postgres.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgres.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.postgres.persistence.existingClaim }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.postgres.persistence.existingClaim }}
+  {{- else if .Values.postgres.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "github-app-playground.labels" . | nindent 10 }}
+          app.kubernetes.io/component: postgres
+      spec:
+        accessModes:
+          {{- range .Values.postgres.persistence.accessModes }}
+          - {{ . | quote }}
+          {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.persistence.size | quote }}
+        {{- if .Values.postgres.persistence.storageClass }}
+        {{- if (eq "-" .Values.postgres.persistence.storageClass) }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: {{ .Values.postgres.persistence.storageClass }}
+        {{- end }}
+        {{- end }}
+  {{- else }}
+      volumes:
+        - name: data
+          emptyDir: {}
+  {{- end }}
+{{- end }}

--- a/charts/github-app-playground/templates/role.yaml
+++ b/charts/github-app-playground/templates/role.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+rules:
+  # src/k8s/job-spawner.ts createNamespacedJob / readNamespacedJobStatus / deleteNamespacedJob
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  # Spawner inspects pod status + optionally tails logs of the isolated-job pod
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+{{- end }}

--- a/charts/github-app-playground/templates/rolebinding.yaml
+++ b/charts/github-app-playground/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "github-app-playground.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "github-app-playground.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/github-app-playground/templates/secret.yaml
+++ b/charts/github-app-playground/templates/secret.yaml
@@ -7,11 +7,13 @@ metadata:
     {{- include "github-app-playground.labels" . | nindent 4 }}
 type: Opaque
 data:
+  # Secret-bound env vars. Keys gated by `if` so only provided values render.
+  # Field order mirrors the numbered groups in src/config.ts.
   {{- $c := .Values.config }}
   {{- $fullname := include "github-app-playground.fullname" . }}
   {{- $appSecret := printf "%s-secret" $fullname }}
 
-  # === GitHub App === (toString guards against --set passing a numeric appId)
+  # --- 1. GitHub App credentials --- (toString guards against --set passing a numeric appId)
   {{- if $c.appId }}
   GITHUB_APP_ID: {{ $c.appId | toString | b64enc | quote }}
   {{- end }}
@@ -22,13 +24,15 @@ data:
   GITHUB_WEBHOOK_SECRET: {{ $c.webhookSecret | toString | b64enc | quote }}
   {{- end }}
 
-  # === AI provider credentials ===
+  # --- 3. Anthropic direct-API credentials ---
   {{- if $c.anthropicApiKey }}
   ANTHROPIC_API_KEY: {{ $c.anthropicApiKey | b64enc | quote }}
   {{- end }}
   {{- if $c.claudeCodeOauthToken }}
   CLAUDE_CODE_OAUTH_TOKEN: {{ $c.claudeCodeOauthToken | b64enc | quote }}
   {{- end }}
+
+  # --- 4. AWS Bedrock credentials (secret subset) ---
   {{- if $c.awsAccessKeyId }}
   AWS_ACCESS_KEY_ID: {{ $c.awsAccessKeyId | b64enc | quote }}
   {{- end }}
@@ -42,12 +46,16 @@ data:
   AWS_BEARER_TOKEN_BEDROCK: {{ $c.awsBearerTokenBedrock | b64enc | quote }}
   {{- end }}
 
-  # === Third-party ===
+  # --- 5. App runtime / behaviour (secret subset) ---
   {{- if $c.context7ApiKey }}
   CONTEXT7_API_KEY: {{ $c.context7ApiKey | b64enc | quote }}
   {{- end }}
 
-  # === Auto-composed URLs (from postgres.* / valkey.* resolution order) ===
+  # --- 8. Shared-runner HTTP target (auto-generated, stable via `lookup`) ---
+  INTERNAL_RUNNER_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "INTERNAL_RUNNER_TOKEN" "secretName" $appSecret "override" $c.internalRunnerToken "root" .) | b64enc | quote }}
+  SHARED_RUNNER_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "SHARED_RUNNER_TOKEN" "secretName" $appSecret "override" $c.sharedRunnerToken "root" .) | b64enc | quote }}
+
+  # --- 9. Data layer (auto-composed URLs from postgres.* / valkey.* resolution order) ---
   {{- $dbUrl := include "github-app-playground.databaseUrl" . }}
   {{- if $dbUrl }}
   DATABASE_URL: {{ $dbUrl | b64enc | quote }}
@@ -57,8 +65,6 @@ data:
   VALKEY_URL: {{ $valkeyUrl | b64enc | quote }}
   {{- end }}
 
-  # === Auto-generated tokens (stable across upgrades via `lookup`) ===
+  # --- 11. Daemon / Orchestrator WebSocket (auto-generated, stable via `lookup`) ---
   DAEMON_AUTH_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "DAEMON_AUTH_TOKEN" "secretName" $appSecret "override" $c.daemonAuthToken "root" .) | b64enc | quote }}
-  INTERNAL_RUNNER_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "INTERNAL_RUNNER_TOKEN" "secretName" $appSecret "override" $c.internalRunnerToken "root" .) | b64enc | quote }}
-  SHARED_RUNNER_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "SHARED_RUNNER_TOKEN" "secretName" $appSecret "override" $c.sharedRunnerToken "root" .) | b64enc | quote }}
 {{- end }}

--- a/charts/github-app-playground/templates/secret.yaml
+++ b/charts/github-app-playground/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.secrets.existingSecret }}
+{{- if not .Values.config.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,38 +7,58 @@ metadata:
     {{- include "github-app-playground.labels" . | nindent 4 }}
 type: Opaque
 data:
-  # GitHub App credentials (required)
-  GITHUB_APP_ID: {{ .Values.secrets.githubAppId | b64enc | quote }}
-  # Multi-line PEM private key — newlines are preserved via b64enc
-  GITHUB_APP_PRIVATE_KEY: {{ .Values.secrets.githubAppPrivateKey | b64enc | quote }}
-  GITHUB_WEBHOOK_SECRET: {{ .Values.secrets.githubWebhookSecret | b64enc | quote }}
+  {{- $c := .Values.config }}
+  {{- $fullname := include "github-app-playground.fullname" . }}
+  {{- $appSecret := printf "%s-secret" $fullname }}
 
-  # Anthropic direct API (required when CLAUDE_PROVIDER=anthropic)
-  {{- if eq .Values.app.claudeProvider "anthropic" }}
-  ANTHROPIC_API_KEY: {{ .Values.secrets.anthropicApiKey | b64enc | quote }}
+  # === GitHub App === (toString guards against --set passing a numeric appId)
+  {{- if $c.appId }}
+  GITHUB_APP_ID: {{ $c.appId | toString | b64enc | quote }}
   {{- end }}
-
-  # AWS credentials for Bedrock (required when CLAUDE_PROVIDER=bedrock)
-  # Only non-empty values are written: empty env vars can interfere with the AWS SDK credential
-  # chain (e.g. IRSA / instance profile). Omitting them lets the SDK fall through correctly.
-  # Prefer IAM roles (IRSA/EC2 instance profile) over static keys in production.
-  {{- if eq .Values.app.claudeProvider "bedrock" }}
-  {{- if .Values.secrets.awsAccessKeyId }}
-  AWS_ACCESS_KEY_ID: {{ .Values.secrets.awsAccessKeyId | b64enc | quote }}
+  {{- if $c.privateKey }}
+  GITHUB_APP_PRIVATE_KEY: {{ $c.privateKey | toString | b64enc | quote }}
   {{- end }}
-  {{- if .Values.secrets.awsSecretAccessKey }}
-  AWS_SECRET_ACCESS_KEY: {{ .Values.secrets.awsSecretAccessKey | b64enc | quote }}
-  {{- end }}
-  {{- if .Values.secrets.awsSessionToken }}
-  AWS_SESSION_TOKEN: {{ .Values.secrets.awsSessionToken | b64enc | quote }}
-  {{- end }}
-  {{- if .Values.secrets.awsBearerTokenBedrock }}
-  AWS_BEARER_TOKEN_BEDROCK: {{ .Values.secrets.awsBearerTokenBedrock | b64enc | quote }}
-  {{- end }}
+  {{- if $c.webhookSecret }}
+  GITHUB_WEBHOOK_SECRET: {{ $c.webhookSecret | toString | b64enc | quote }}
   {{- end }}
 
-  # Optional: Context7 API key for library documentation MCP server
-  {{- if .Values.secrets.context7ApiKey }}
-  CONTEXT7_API_KEY: {{ .Values.secrets.context7ApiKey | b64enc | quote }}
+  # === AI provider credentials ===
+  {{- if $c.anthropicApiKey }}
+  ANTHROPIC_API_KEY: {{ $c.anthropicApiKey | b64enc | quote }}
   {{- end }}
+  {{- if $c.claudeCodeOauthToken }}
+  CLAUDE_CODE_OAUTH_TOKEN: {{ $c.claudeCodeOauthToken | b64enc | quote }}
+  {{- end }}
+  {{- if $c.awsAccessKeyId }}
+  AWS_ACCESS_KEY_ID: {{ $c.awsAccessKeyId | b64enc | quote }}
+  {{- end }}
+  {{- if $c.awsSecretAccessKey }}
+  AWS_SECRET_ACCESS_KEY: {{ $c.awsSecretAccessKey | b64enc | quote }}
+  {{- end }}
+  {{- if $c.awsSessionToken }}
+  AWS_SESSION_TOKEN: {{ $c.awsSessionToken | b64enc | quote }}
+  {{- end }}
+  {{- if $c.awsBearerTokenBedrock }}
+  AWS_BEARER_TOKEN_BEDROCK: {{ $c.awsBearerTokenBedrock | b64enc | quote }}
+  {{- end }}
+
+  # === Third-party ===
+  {{- if $c.context7ApiKey }}
+  CONTEXT7_API_KEY: {{ $c.context7ApiKey | b64enc | quote }}
+  {{- end }}
+
+  # === Auto-composed URLs (from postgres.* / valkey.* resolution order) ===
+  {{- $dbUrl := include "github-app-playground.databaseUrl" . }}
+  {{- if $dbUrl }}
+  DATABASE_URL: {{ $dbUrl | b64enc | quote }}
+  {{- end }}
+  {{- $valkeyUrl := include "github-app-playground.valkeyUrl" . }}
+  {{- if $valkeyUrl }}
+  VALKEY_URL: {{ $valkeyUrl | b64enc | quote }}
+  {{- end }}
+
+  # === Auto-generated tokens (stable across upgrades via `lookup`) ===
+  DAEMON_AUTH_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "DAEMON_AUTH_TOKEN" "secretName" $appSecret "override" $c.daemonAuthToken "root" .) | b64enc | quote }}
+  INTERNAL_RUNNER_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "INTERNAL_RUNNER_TOKEN" "secretName" $appSecret "override" $c.internalRunnerToken "root" .) | b64enc | quote }}
+  SHARED_RUNNER_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "SHARED_RUNNER_TOKEN" "secretName" $appSecret "override" $c.sharedRunnerToken "root" .) | b64enc | quote }}
 {{- end }}

--- a/charts/github-app-playground/templates/shared-runner-deployment.yaml
+++ b/charts/github-app-playground/templates/shared-runner-deployment.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.sharedRunner.enabled }}
+# Forward-compatible stub. The app-side POST /internal/run handler is not yet
+# registered in github-app-playground (verified 2026-04-17 — see
+# src/app.ts, src/k8s/shared-runner-dispatcher.ts). Deploying this with
+# config.agentJobMode=shared-runner will cause webhook dispatches to 404 on
+# the runner pod. Keep sharedRunner.enabled=false until the handler ships.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}-shared-runner
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+    app.kubernetes.io/component: shared-runner
+spec:
+  replicas: {{ .Values.sharedRunner.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "github-app-playground.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: shared-runner
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "github-app-playground.labels" . | nindent 8 }}
+        app.kubernetes.io/component: shared-runner
+    spec:
+      serviceAccountName: {{ include "github-app-playground.serviceAccountName" . }}
+      {{- with .Values.sharedRunner.podSecurityContext | default .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: shared-runner
+          {{- with .Values.sharedRunner.securityContext | default .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- $img := .Values.sharedRunner.image | default dict }}
+          image: "{{ $img.repository | default .Values.image.repository }}:{{ $img.tag | default (.Values.image.tag | default .Chart.AppVersion) }}"
+          imagePullPolicy: {{ $img.pullPolicy | default .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.sharedRunner.service.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "github-app-playground.fullname" . }}-config
+            - secretRef:
+                name: {{ include "github-app-playground.secretName" . }}
+          # Override PORT so the runner listens on its own port. INTERNAL_RUNNER
+          # is forward-compat: once the app registers the handler, it will read
+          # this env var to swap webhook mode for runner mode.
+          env:
+            - name: PORT
+              value: {{ .Values.sharedRunner.service.port | quote }}
+            - name: INTERNAL_RUNNER
+              value: "true"
+          {{- with .Values.sharedRunner.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.sharedRunner.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sharedRunner.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.sharedRunner.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/github-app-playground/templates/shared-runner-service.yaml
+++ b/charts/github-app-playground/templates/shared-runner-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.sharedRunner.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}-shared-runner
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+    app.kubernetes.io/component: shared-runner
+spec:
+  type: {{ .Values.sharedRunner.service.type }}
+  ports:
+    - port: {{ .Values.sharedRunner.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "github-app-playground.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: shared-runner
+{{- end }}

--- a/charts/github-app-playground/templates/valkey-deployment.yaml
+++ b/charts/github-app-playground/templates/valkey-deployment.yaml
@@ -1,0 +1,94 @@
+{{- if .Values.valkey.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}-valkey
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+spec:
+  replicas: {{ .Values.valkey.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "github-app-playground.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: valkey
+  template:
+    metadata:
+      labels:
+        {{- include "github-app-playground.labels" . | nindent 8 }}
+        app.kubernetes.io/component: valkey
+    spec:
+      {{- with .Values.valkey.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: valkey
+          {{- with .Values.valkey.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.valkey.image.repository }}:{{ .Values.valkey.image.tag }}"
+          imagePullPolicy: {{ .Values.valkey.image.pullPolicy }}
+          ports:
+            - name: valkey
+              containerPort: 6379
+              protocol: TCP
+          {{- if .Values.valkey.auth.enabled }}
+          # Password is injected into the server CLI rather than read from env so Valkey
+          # actually enforces auth (the upstream image does not enable AUTH from env alone).
+          command:
+            - valkey-server
+            - --requirepass
+            - $(VALKEY_PASSWORD)
+          env:
+            - name: VALKEY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "github-app-playground.valkeySecretName" . }}
+                  key: password
+          {{- end }}
+          {{- if .Values.valkey.persistence.enabled }}
+          volumeMounts:
+            - name: valkey-data
+              mountPath: /data
+          {{- end }}
+          {{- with .Values.valkey.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          livenessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            failureThreshold: 3
+      {{- if .Values.valkey.persistence.enabled }}
+      volumes:
+        - name: valkey-data
+          persistentVolumeClaim:
+            claimName: {{ include "github-app-playground.fullname" . }}-valkey-pvc
+      {{- end }}
+      {{- with .Values.valkey.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.valkey.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.valkey.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/github-app-playground/templates/valkey-pvc.yaml
+++ b/charts/github-app-playground/templates/valkey-pvc.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.valkey.enabled .Values.valkey.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}-valkey-pvc
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+spec:
+  accessModes:
+    {{- range .Values.valkey.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.valkey.persistence.size | quote }}
+  {{- if .Values.valkey.persistence.storageClass }}
+  {{- if (eq "-" .Values.valkey.persistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.valkey.persistence.storageClass }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/github-app-playground/templates/valkey-secret.yaml
+++ b/charts/github-app-playground/templates/valkey-secret.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.valkey.enabled (not .Values.valkey.auth.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}-valkey-secret
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+type: Opaque
+data:
+  {{- if .Values.valkey.auth.enabled }}
+  password: {{ include "github-app-playground.valkeyPassword" . | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/github-app-playground/templates/valkey-service.yaml
+++ b/charts/github-app-playground/templates/valkey-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.valkey.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "github-app-playground.fullname" . }}-valkey
+  labels:
+    {{- include "github-app-playground.labels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+spec:
+  type: {{ .Values.valkey.service.type }}
+  ports:
+    - port: {{ .Values.valkey.service.port }}
+      targetPort: valkey
+      protocol: TCP
+      name: valkey
+  selector:
+    {{- include "github-app-playground.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: valkey
+{{- end }}

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -256,89 +256,100 @@ sharedRunner:
 # ─────────────────────────── APPLICATION CONFIG ───────────────────────
 # `config:` is a flat 1:1 mirror of the Zod schema in
 # /Users/chrislee/srv/github/github-app-playground/src/config.ts.
-# Field names match Zod keys. The chart routes each key to ConfigMap or Secret
-# based on a hard-coded sensitivity list in the templates.
+# Field names and group order match the numbered sections of that file.
+# The chart routes each key to ConfigMap or Secret based on a hardcoded
+# sensitivity list in the templates.
 config:
   existingSecret: ""                            # Chart-level escape hatch. When set, chart-managed Secret is not rendered.
 
-  # GitHub App — required when running as the webhook server (ORCHESTRATOR_URL unset).
-  appId: ""
+  # --- 1. GitHub App credentials (server mode) ---
+  appId: ""                                     # Required in server mode (orchestratorUrl unset).
   privateKey: ""                                # PEM contents, not a file path.
   webhookSecret: ""
 
-  # AI provider
+  # --- 2. AI provider selection ---
   provider: anthropic                           # anthropic | bedrock.
+  model: ""                                     # Required when provider=bedrock.
+
+  # --- 3. Anthropic direct-API credentials ---
   anthropicApiKey: ""                           # Required when provider=anthropic and claudeCodeOauthToken is empty.
   claudeCodeOauthToken: ""                      # Alternative to anthropicApiKey. Requires allowedOwners.
-  model: ""                                     # Required when provider=bedrock.
+
+  # --- 4. AWS Bedrock credentials ---
   awsRegion: ""                                 # Required when provider=bedrock.
-  awsProfile: ""                                # Set only when using a shared AWS credentials file.
+  awsProfile: ""                                # Set only for local SSO (e.g. le aws login).
   awsAccessKeyId: ""                            # Set for static AWS creds; otherwise leave empty.
   awsSecretAccessKey: ""
   awsSessionToken: ""                           # Set for temporary AWS STS creds.
-  awsBearerTokenBedrock: ""                     # Set to use Bedrock bearer-token auth instead of sigv4.
-  anthropicBedrockBaseUrl: ""                   # Override only to use a Bedrock-compatible proxy.
+  awsBearerTokenBedrock: ""                     # Set to use Bedrock bearer-token auth (GitHub Actions OIDC).
+  anthropicBedrockBaseUrl: ""                   # Override only to front Bedrock with a VPC endpoint / proxy.
 
-  context7ApiKey: ""                            # Enables the Context7 MCP server. Leave empty to disable.
-
+  # --- 5. App runtime / behaviour ---
+  context7ApiKey: ""                            # Lifts the Context7 MCP rate limit. Unset works.
   cloneBaseDir: /tmp/bot-workspaces             # Must match workspace.persistence mount path.
   cloneDepth: 50                                # Git shallow-clone depth.
-  claudeCodePath: ""                            # Override only to pin a specific claude CLI binary path.
-
-  triggerPhrase: "@chrisleekr-bot"              # Change when using a different GitHub App bot handle.
+  triggerPhrase: "@chrisleekr-bot"              # Must match the GitHub App's bot login exactly.
   port: 3000                                    # Must match the container/service ports.
   logLevel: info                                # fatal | error | warn | info | debug | trace.
   nodeEnv: production
   maxConcurrentRequests: 3
   agentTimeoutMs: 600000
-  agentMaxTurns: ""                             # Leave empty to use defaultMaxTurns.
+  agentMaxTurns: ""                             # Leave empty to use defaultMaxTurns or triage-derived turns.
+  claudeCodePath: ""                            # Required only when claude-code is installed globally (e.g. Docker).
   allowedOwners: ""                             # Comma-separated. Required when claudeCodeOauthToken is set.
 
+  # --- 6. Dispatch mode (Phase 2+ / Phase 3) ---
   agentJobMode: inline                          # inline | daemon | shared-runner | isolated-job | auto.
   defaultDispatchTarget: shared-runner          # Cannot be inline when agentJobMode=auto.
 
-  # isolated-job spawner — only consulted when agentJobMode is isolated-job or auto.
+  # --- 7. K8s Job spawner (isolated-job target) ---
   jobNamespace: ""                              # Leave empty to use the release namespace.
   jobImage: ""                                  # Leave empty to inherit .Values.image.
   jobTtlSeconds: 300
-  jobActiveDeadlineSeconds: 1800                # Zod caps at 3500.
+  jobActiveDeadlineSeconds: 1800                # Zod caps at 3500 (installation-token TTL margin).
   jobWatchPollIntervalMs: 5000
-  jobMaxCostUsd: 80
-  jobMaxRetries: 3                              # App-level retry. K8s backoffLimit is hardcoded to 0 in the spawner.
-  maxConcurrentIsolatedJobs: 3
-  pendingIsolatedJobQueueMax: 20
 
-  # Shared runner client — only consulted when agentJobMode is shared-runner or auto.
-  internalRunnerUrl: ""                         # Required. e.g. http://<release>-shared-runner:7081.
+  # --- 8. Shared-runner HTTP target ---
+  internalRunnerUrl: ""                         # Required when agentJobMode is shared-runner or auto.
   internalRunnerToken: ""                       # Leave empty to auto-generate and persist.
-  sharedRunnerToken: ""                         # Leave empty to auto-generate and persist.
+  sharedRunnerToken: ""                         # ADR-011 reserved; leave empty to auto-generate.
 
-  # Data layer — required when agentJobMode is not inline.
-  databaseUrl: ""                               # Leave empty to compose from postgres.* or postgres.external.*.
+  # --- 9. Data layer (required when agentJobMode is not inline) ---
   valkeyUrl: ""                                 # Leave empty to compose from valkey.* or valkey.external.*.
+  databaseUrl: ""                               # Leave empty to compose from postgres.* or postgres.external.*.
 
-  # Orchestrator / daemon — required when agentJobMode is not inline.
-  wsPort: 3002
-  orchestratorUrl: ""                           # Set only when running the daemon worker binary, not the webhook.
+  # --- 10. Orchestrator ---
+  wsPort: 3002                                  # Must differ from config.port.
+  jobMaxCostUsd: 80                             # Placeholder today (not enforced in code).
+
+  # --- 11. Daemon / Orchestrator WebSocket (Phase 2) ---
   daemonAuthToken: ""                           # Leave empty to auto-generate and persist.
+  orchestratorUrl: ""                           # Setting this flips the process to DAEMON mode (webhook HTTP not started).
   heartbeatIntervalMs: 30000
-  heartbeatTimeoutMs: 90000
-  staleExecutionThresholdMs: 600000
-  daemonDrainTimeoutMs: 300000
+  heartbeatTimeoutMs: 90000                     # Keep >= 2 x heartbeatIntervalMs.
+  staleExecutionThresholdMs: 600000             # Must exceed agentTimeoutMs.
+  daemonDrainTimeoutMs: 300000                  # Set >= agentTimeoutMs to avoid mid-run kills on SIGTERM.
+  jobMaxRetries: 3                              # Daemon-dispatch retry only. isolated-job ignores this (FR-021).
   offerTimeoutMs: 5000
   daemonUpdateStrategy: exit                    # exit | pull | notify.
   daemonUpdateDelayMs: 0
-  daemonEphemeral: false
+  daemonEphemeral: false                        # Placeholder today (not enforced in code).
   daemonMemoryFloorMb: 512
   daemonDiskFloorMb: 1024
 
-  # Triage — only consulted when agentJobMode=auto.
-  triageEnabled: true
+  # --- 12. Triage pre-classifier (auto mode) ---
+  triageEnabled: true                           # Kill-switch for the triage LLM call.
   triageModel: haiku-3-5
-  triageConfidenceThreshold: 1.0                # Lower to 0.75 only after SC-003/SC-004 stabilise in production.
+  triageConfidenceThreshold: 1.0                # Lower to 0.75 only after SC-003/SC-004 stabilise.
   triageMaxTokens: 256
   triageTimeoutMs: 5000
+
+  # --- 13. Complexity → maxTurns mapping (FR-008a) ---
   triageMaxTurnsTrivial: 10
   triageMaxTurnsModerate: 30
   triageMaxTurnsComplex: 50
   defaultMaxTurns: 30
+
+  # --- 14. Isolated-job capacity back-pressure (FR-018, US3) ---
+  maxConcurrentIsolatedJobs: 3
+  pendingIsolatedJobQueueMax: 20

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -196,6 +196,10 @@ valkey:
       existingSecret: ""                        # Preferred over external.auth.password.
       existingSecretPasswordKey: VALKEY_PASSWORD
       password: ""                              # Use only if existingSecret is empty. Avoid checking in.
+  # Must stay at 1 while persistence.enabled is true. Every replica would mount
+  # the same RWO PVC, which either fails scheduling (2nd pod Pending on the
+  # volume lock) or corrupts data. Switch to StatefulSet + volumeClaimTemplates
+  # if you need multi-replica Valkey.
   replicaCount: 1
   image:
     repository: valkey/valkey
@@ -254,11 +258,10 @@ sharedRunner:
   affinity: {}
 
 # ─────────────────────────── APPLICATION CONFIG ───────────────────────
-# `config:` is a flat 1:1 mirror of the Zod schema in
-# /Users/chrislee/srv/github/github-app-playground/src/config.ts.
-# Field names and group order match the numbered sections of that file.
-# The chart routes each key to ConfigMap or Secret based on a hardcoded
-# sensitivity list in the templates.
+# `config:` is a flat 1:1 mirror of the Zod schema in the app image's
+# `src/config.ts`. Field names and group order match the numbered
+# sections of that schema. The chart routes each key to ConfigMap or
+# Secret based on a hardcoded sensitivity list in the templates.
 config:
   existingSecret: ""                            # Chart-level escape hatch. When set, chart-managed Secret is not rendered.
 

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -1,41 +1,36 @@
 # Default values for github-app-playground.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
+# This is a YAML-formatted file. Declare variables to be passed into your templates.
+#
+# Commenting rule: every non-obvious parameter has one short line that names the
+# trigger condition (when to set, when to leave default). No narrative.
 
-# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+# ─────────────────────────── INFRASTRUCTURE ───────────────────────────
+
 replicaCount: 1
 
-# This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
   repository: chrisleekr/github-app-playground
-  # This sets the pull policy for images.
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: ""                                       # Leave empty to use .Chart.AppVersion.
 
-# This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
-# This is to override the chart name.
 nameOverride: ""
 fullnameOverride: ""
 
-# This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
 serviceAccount:
-  # Specifies whether a service account should be created
   create: true
-  # The app does not require Kubernetes RBAC access, so API credentials should not be auto-mounted
-  automount: false
-  # Annotations to add to the service account (e.g. for IRSA on EKS)
-  annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: ""
+  # Auto-mount the SA token so src/k8s/job-spawner.ts can call the Kubernetes API
+  # when config.agentJobMode is isolated-job or auto. Safe to leave true when RBAC
+  # is disabled: the token still grants nothing without a Role binding.
+  automount: true
+  annotations: {}                               # Add IRSA / cloud IAM bindings here.
+  name: ""                                      # Leave empty to use the fullname template.
 
-# This is for setting Kubernetes Annotations to a Pod.
-# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+# Role + RoleBinding for in-cluster Job spawning (isolated-job mode).
+rbac:
+  create: false                                 # Set true when config.agentJobMode is isolated-job or auto.
+
 podAnnotations: {}
-# This is for setting Kubernetes Labels to a Pod.
-# For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
 podSecurityContext:
@@ -47,20 +42,15 @@ securityContext:
   capabilities:
     drop:
       - ALL
-  # Must be false: the Node.js runtime writes to paths outside the workspace volume
-  # (e.g. npm cache, OS temp files). CLONE_BASE_DIR itself is on the mounted PVC.
+  # Must be false: the Node.js runtime writes outside the workspace PVC (npm cache, OS tmp).
   readOnlyRootFilesystem: false
   runAsNonRoot: true
   runAsUser: 1000
 
-# This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
 service:
-  # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
   type: ClusterIP
-  # External service port
   port: 80
 
-# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ingress:
   enabled: false
   className: ""
@@ -68,18 +58,16 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
-    - host: github-app.local
+    - host: chart-example.local                 # Replace with your real host in the consumer values file.
       paths:
         - path: /
           pathType: Prefix
   tls: []
-  #  - secretName: github-app-tls
+  #  - secretName: chart-example-tls
   #    hosts:
-  #      - github-app.local
+  #      - chart-example.local
 
-# Resource recommendations are based on MAX_CONCURRENT_REQUESTS (default 3) * ~512Mi per request.
-# Adjust limits based on your actual concurrency setting.
-# For more information checkout: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+# Resource recommendations scale with config.maxConcurrentRequests (~512Mi per session).
 resources:
   limits:
     cpu: 2000m
@@ -88,11 +76,9 @@ resources:
     cpu: 500m
     memory: 512Mi
 
-# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
   httpGet:
     path: /healthz
-    # Named port reference keeps probes in sync with app.port automatically
     port: http
   initialDelaySeconds: 15
   periodSeconds: 10
@@ -103,7 +89,6 @@ livenessProbe:
 readinessProbe:
   httpGet:
     path: /readyz
-    # Named port reference keeps probes in sync with app.port automatically
     port: http
   initialDelaySeconds: 5
   periodSeconds: 10
@@ -111,9 +96,8 @@ readinessProbe:
   failureThreshold: 3
   successThreshold: 1
 
-# This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
-# Note: autoscaling is disabled by default because the bot handles stateful repo clone workspaces
-# that are bound to a specific pod. Enable only if using a shared PVC (ReadWriteMany).
+# Autoscaling is unsafe when workspaces are bound to a single pod (default). Enable
+# only with a ReadWriteMany workspace PVC.
 autoscaling:
   enabled: false
   minReplicas: 1
@@ -121,118 +105,240 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
 
-# Pod Disruption Budget for more information checkout: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
 podDisruptionBudget:
   enabled: false
   minAvailable: 1
   # maxUnavailable: 1
 
-# Graceful shutdown period. The app waits up to 290s for in-flight requests before exiting.
-# Must be >= app shutdown timeout (290s). See: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination
+# Must be >= app shutdown timeout (290s).
 terminationGracePeriodSeconds: 300
 
-# Workspace persistence for cloned repositories.
-# The app clones GitHub repos to CLONE_BASE_DIR for each bot request and cleans them up after.
-# A persistent volume is recommended over emptyDir to survive pod restarts mid-request.
+# Workspace PVC for transient repo clones (CLONE_BASE_DIR).
 workspace:
   persistence:
-    enabled: true
-    storageClass: ""
+    enabled: true                               # Set false for ephemeral (tests only).
+    storageClass: ""                            # Leave empty for cluster default StorageClass.
+    # storageClass: "-"                         # Set to "-" to disable dynamic provisioning.
     accessModes:
       - ReadWriteOnce
     size: 10Gi
-    # Set to use a pre-existing PVC instead of creating one
-    existingClaim: ""
+    existingClaim: ""                           # Set to reuse a pre-existing PVC.
 
-# Additional volumes on the output Deployment definition.
 volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
-
-# Additional volumeMounts on the output Deployment definition.
 volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
-
 nodeSelector: {}
-
 tolerations: []
-
 affinity: {}
 
-# Extra environment variables injected directly into the container.
-# Use for values that don't fit the typed app/secrets sections (e.g. AWS_PROFILE for local SSO,
-# HTTP_PROXY, or any other ad-hoc env var).
-# See: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+# Extra env vars appended to the webhook container. Use for ad-hoc cases that don't fit `config:`.
 extraEnv: []
-# - name: AWS_PROFILE
-#   value: my-sso-profile
 # - name: HTTP_PROXY
 #   value: http://proxy.example.com:3128
 
-# Application configuration (non-sensitive values — placed in a ConfigMap)
-# All values correspond to environment variables validated by src/config.ts
-app:
-  # HTTP server port — must match the containerPort named 'http' in the Deployment
-  port: 3000
-  # Node.js environment
-  nodeEnv: production
-  # Logging level: fatal | error | warn | info | debug | trace
-  logLevel: info
-  # Phrase that triggers the bot when mentioned in PR/issue comments
-  triggerPhrase: "@chrisleekr-bot"
-  # Maximum number of simultaneous Claude agent sessions
-  # Memory usage scales with this value (~512Mi per session)
-  maxConcurrentRequests: 3
-  # Timeout for each Claude agent run in milliseconds (default 10 minutes)
-  agentTimeoutMs: 600000
-  # Number of git commits to fetch when cloning a repo (shallow clone depth)
-  cloneDepth: 50
-  # Base directory for temporary repo clones (must match workspace.persistence mount)
-  cloneBaseDir: /tmp/bot-workspaces
+# ─── In-chart stateful deps (each supports in-cluster or external) ───
 
-  # AI provider: "anthropic" (direct API) or "bedrock" (AWS Bedrock)
-  claudeProvider: anthropic
+postgres:
+  enabled: false                                # Set true to provision Postgres in-cluster.
+  # Use an existing Postgres instead of provisioning one. Do not combine with postgres.enabled.
+  external:
+    enabled: false
+    host: ""                                    # Required when external.enabled is true.
+    port: 5432
+    username: ""                                # Required when external.enabled is true.
+    database: ""                                # Required when external.enabled is true.
+    sslmode: disable                            # disable | require | verify-full.
+    existingSecret: ""                          # Preferred over external.password. Secret in release namespace.
+    existingSecretPasswordKey: POSTGRES_PASSWORD
+    password: ""                                # Use only if existingSecret is empty. Avoid checking in.
+  image:
+    repository: pgvector/pgvector
+    tag: pg17                                   # Pin only when changing Postgres major.
+    pullPolicy: IfNotPresent
+  auth:
+    existingSecret: ""                          # Set to skip chart-managed password Secret. Must contain POSTGRES_PASSWORD.
+    username: github_app
+    database: github_app
+  service:
+    type: ClusterIP
+    port: 5432
+  persistence:
+    enabled: true                               # Set false only for ephemeral tests.
+    existingClaim: ""                           # Set to reuse a pre-existing PVC.
+    accessModes: [ReadWriteOnce]
+    size: 5Gi
+    storageClass: ""                            # Leave empty for cluster default.
+    # storageClass: "-"                         # Set to "-" to disable dynamic provisioning.
+  resources:
+    limits:
+      cpu: "1"
+      memory: 1Gi
+    requests:
+      cpu: 200m
+      memory: 256Mi
+  podSecurityContext:
+    fsGroup: 999
+    runAsUser: 999
+    runAsNonRoot: true
+  securityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
-  # Override only when using a custom image where claude-code is not at the default path.
-  # Leave empty to inherit the path baked into the Docker image via ENV.
-  # Default in official image: /usr/lib/node_modules/@anthropic-ai/claude-code/cli.js
-  claudeCodePath: ""
+valkey:
+  enabled: false                                # Set true to provision Valkey in-cluster.
+  external:
+    enabled: false                              # Set true to use an existing Valkey. Do not combine with valkey.enabled.
+    host: ""                                    # Required when external.enabled is true.
+    port: 6379
+    database: 0
+    auth:
+      enabled: true                             # Set false only when the external Valkey has no auth.
+      existingSecret: ""                        # Preferred over external.auth.password.
+      existingSecretPasswordKey: VALKEY_PASSWORD
+      password: ""                              # Use only if existingSecret is empty. Avoid checking in.
+  replicaCount: 1
+  image:
+    repository: valkey/valkey
+    tag: "8-alpine"
+    pullPolicy: IfNotPresent
+  auth:
+    enabled: true                               # Set false only for local/no-auth tests.
+    password: ""                                # Leave empty to auto-generate and persist.
+    existingSecret: ""                          # Set to skip chart-managed password Secret.
+  service:
+    type: ClusterIP
+    port: 6379
+  persistence:
+    enabled: true
+    storageClass: ""                            # Leave empty for cluster default.
+    # storageClass: "-"                         # Set to "-" to disable dynamic provisioning.
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+  resources:
+    limits:
+      cpu: 250m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi
+  podSecurityContext:
+    fsGroup: 999
+    runAsUser: 999
+    runAsNonRoot: true
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 999
+    runAsGroup: 999
+    # Valkey writes RDB/AOF snapshots under /data; cannot be read-only.
+    readOnlyRootFilesystem: false
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
-  # AWS Bedrock provider settings (only required when claudeProvider=bedrock)
-  awsRegion: ""
-  # Claude model ID (e.g. us.anthropic.claude-opus-4-5-v1:0)
-  claudeModel: ""
-  # Optional custom Bedrock endpoint URL
-  anthropicBedrockBaseUrl: ""
+# Optional extra Deployment running the same image as the webhook, in
+# "shared runner" mode. Keep disabled until the app registers POST /internal/run.
+sharedRunner:
+  enabled: false
+  replicaCount: 1
+  image: {}                                     # Leave empty to inherit .Values.image.
+  service:
+    type: ClusterIP
+    port: 7081
+  resources: {}                                 # Set per environment; no default.
+  podSecurityContext: {}
+  securityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
-# Sensitive credentials (placed in a Kubernetes Secret)
-# Set existingSecret to use a pre-existing secret instead of creating one.
-# When using existingSecret, ensure it contains all the keys listed below.
-secrets:
-  # Name of an existing Secret. If set, the chart will NOT create a new Secret.
-  existingSecret: ""
+# ─────────────────────────── APPLICATION CONFIG ───────────────────────
+# `config:` is a flat 1:1 mirror of the Zod schema in
+# /Users/chrislee/srv/github/github-app-playground/src/config.ts.
+# Field names match Zod keys. The chart routes each key to ConfigMap or Secret
+# based on a hard-coded sensitivity list in the templates.
+config:
+  existingSecret: ""                            # Chart-level escape hatch. When set, chart-managed Secret is not rendered.
 
-  # GitHub App credentials (required)
-  # Create a GitHub App at https://github.com/settings/apps
-  githubAppId: ""
-  # Multi-line PEM private key — newlines must be preserved
-  githubAppPrivateKey: ""
-  githubWebhookSecret: ""
+  # GitHub App — required when running as the webhook server (ORCHESTRATOR_URL unset).
+  appId: ""
+  privateKey: ""                                # PEM contents, not a file path.
+  webhookSecret: ""
 
-  # Anthropic API key (required when app.claudeProvider=anthropic)
-  anthropicApiKey: ""
-
-  # AWS credentials for Bedrock (required when app.claudeProvider=bedrock)
-  # Prefer IAM roles (IRSA/EC2 instance profile) over static keys in production
-  awsAccessKeyId: ""
+  # AI provider
+  provider: anthropic                           # anthropic | bedrock.
+  anthropicApiKey: ""                           # Required when provider=anthropic and claudeCodeOauthToken is empty.
+  claudeCodeOauthToken: ""                      # Alternative to anthropicApiKey. Requires allowedOwners.
+  model: ""                                     # Required when provider=bedrock.
+  awsRegion: ""                                 # Required when provider=bedrock.
+  awsProfile: ""                                # Set only when using a shared AWS credentials file.
+  awsAccessKeyId: ""                            # Set for static AWS creds; otherwise leave empty.
   awsSecretAccessKey: ""
-  awsSessionToken: ""
-  # AWS Bedrock bearer token (alternative to access key auth)
-  awsBearerTokenBedrock: ""
+  awsSessionToken: ""                           # Set for temporary AWS STS creds.
+  awsBearerTokenBedrock: ""                     # Set to use Bedrock bearer-token auth instead of sigv4.
+  anthropicBedrockBaseUrl: ""                   # Override only to use a Bedrock-compatible proxy.
 
-  # Optional: Context7 API key for library documentation MCP server
-  context7ApiKey: ""
+  context7ApiKey: ""                            # Enables the Context7 MCP server. Leave empty to disable.
+
+  cloneBaseDir: /tmp/bot-workspaces             # Must match workspace.persistence mount path.
+  cloneDepth: 50                                # Git shallow-clone depth.
+  claudeCodePath: ""                            # Override only to pin a specific claude CLI binary path.
+
+  triggerPhrase: "@chrisleekr-bot"              # Change when using a different GitHub App bot handle.
+  port: 3000                                    # Must match the container/service ports.
+  logLevel: info                                # fatal | error | warn | info | debug | trace.
+  nodeEnv: production
+  maxConcurrentRequests: 3
+  agentTimeoutMs: 600000
+  agentMaxTurns: ""                             # Leave empty to use defaultMaxTurns.
+  allowedOwners: ""                             # Comma-separated. Required when claudeCodeOauthToken is set.
+
+  agentJobMode: inline                          # inline | daemon | shared-runner | isolated-job | auto.
+  defaultDispatchTarget: shared-runner          # Cannot be inline when agentJobMode=auto.
+
+  # isolated-job spawner — only consulted when agentJobMode is isolated-job or auto.
+  jobNamespace: ""                              # Leave empty to use the release namespace.
+  jobImage: ""                                  # Leave empty to inherit .Values.image.
+  jobTtlSeconds: 300
+  jobActiveDeadlineSeconds: 1800                # Zod caps at 3500.
+  jobWatchPollIntervalMs: 5000
+  jobMaxCostUsd: 80
+  jobMaxRetries: 3                              # App-level retry. K8s backoffLimit is hardcoded to 0 in the spawner.
+  maxConcurrentIsolatedJobs: 3
+  pendingIsolatedJobQueueMax: 20
+
+  # Shared runner client — only consulted when agentJobMode is shared-runner or auto.
+  internalRunnerUrl: ""                         # Required. e.g. http://<release>-shared-runner:7081.
+  internalRunnerToken: ""                       # Leave empty to auto-generate and persist.
+  sharedRunnerToken: ""                         # Leave empty to auto-generate and persist.
+
+  # Data layer — required when agentJobMode is not inline.
+  databaseUrl: ""                               # Leave empty to compose from postgres.* or postgres.external.*.
+  valkeyUrl: ""                                 # Leave empty to compose from valkey.* or valkey.external.*.
+
+  # Orchestrator / daemon — required when agentJobMode is not inline.
+  wsPort: 3002
+  orchestratorUrl: ""                           # Set only when running the daemon worker binary, not the webhook.
+  daemonAuthToken: ""                           # Leave empty to auto-generate and persist.
+  heartbeatIntervalMs: 30000
+  heartbeatTimeoutMs: 90000
+  staleExecutionThresholdMs: 600000
+  daemonDrainTimeoutMs: 300000
+  offerTimeoutMs: 5000
+  daemonUpdateStrategy: exit                    # exit | pull | notify.
+  daemonUpdateDelayMs: 0
+  daemonEphemeral: false
+  daemonMemoryFloorMb: 512
+  daemonDiskFloorMb: 1024
+
+  # Triage — only consulted when agentJobMode=auto.
+  triageEnabled: true
+  triageModel: haiku-3-5
+  triageConfidenceThreshold: 1.0                # Lower to 0.75 only after SC-003/SC-004 stabilise in production.
+  triageMaxTokens: 256
+  triageTimeoutMs: 5000
+  triageMaxTurnsTrivial: 10
+  triageMaxTurnsModerate: 30
+  triageMaxTurnsComplex: 50
+  defaultMaxTurns: 30

--- a/ct.yaml
+++ b/ct.yaml
@@ -4,3 +4,7 @@ chart-dirs:
   - charts
 # Fail if a changed chart's version has not been incremented
 check-version-increment: true
+# Skip maintainer validation. ct hits https://api.github.com/users/<name> per
+# maintainer; every chart here uses display name "Chris Lee" which 404s. The
+# GitHub profile is already recorded via maintainers[].url.
+validate-maintainers: false


### PR DESCRIPTION
## Summary

The `github-app-playground` app shipped Phase 2 (daemon/orchestrator) and Phase 3 (triage + dispatch cascade) in image `v1.1.0`, but the Helm chart at `0.1.0` / appVersion `1.0.0` only wired Phase 1 env vars. Deploying the newer image against the old chart crashes at startup because `src/config.ts` requires `DATABASE_URL` / `VALKEY_URL` / `DAEMON_AUTH_TOKEN` whenever `AGENT_JOB_MODE !== "inline"`.

This PR extends the chart so a single `helm upgrade` can take a cluster from Phase 1 to the full Phase 3 operational surface, with every new component gated `enabled: false` by default — existing inline deploys keep working untouched.

### Before / After

Before — Phase 1 chart, no data layer, no dispatch modes:

```mermaid
flowchart LR
    classDef keep fill:#1f6feb,stroke:#0b2d5c,color:#ffffff,stroke-width:2px
    classDef missing fill:#d4d4d8,stroke:#52525b,color:#27272a,stroke-width:1px,stroke-dasharray: 4 4

    GH["GitHub webhook"]:::keep --> WH["webhook Deployment<br/>image 1.0.0"]:::keep
    WH --> WS["workspace PVC"]:::keep
    WH -.-> PG["Postgres<br/>not provisioned"]:::missing
    WH -.-> VK["Valkey<br/>not provisioned"]:::missing
    WH -.-> JOB["isolated-job<br/>no RBAC"]:::missing
    WH -.-> SR["shared-runner<br/>no Deployment"]:::missing
```

After — Phase 4 chart, every target reachable, all off by default:

```mermaid
flowchart LR
    classDef keep fill:#1f6feb,stroke:#0b2d5c,color:#ffffff,stroke-width:2px
    classDef added fill:#2da44e,stroke:#0d4429,color:#ffffff,stroke-width:2px
    classDef gated fill:#9a6700,stroke:#3b2300,color:#ffffff,stroke-width:2px

    GH["GitHub webhook"]:::keep --> WH["webhook Deployment<br/>image 1.1.0"]:::keep
    WH --> WS["workspace PVC"]:::keep
    WH --> DISP["dispatch cascade<br/>inline daemon shared-runner<br/>isolated-job auto"]:::added
    DISP --> PG["Postgres StatefulSet<br/>pgvector pg17<br/>postgres.enabled"]:::added
    DISP --> VK["Valkey Deployment<br/>valkey 8-alpine<br/>valkey.enabled"]:::added
    DISP --> SR["shared-runner Deployment<br/>sharedRunner.enabled<br/>forward-compat"]:::gated
    DISP --> JOB["isolated-job<br/>batch/jobs Role<br/>rbac.create"]:::added
    PG -. external PG supported .-> EXTPG["postgres.external.enabled"]:::added
    VK -. external Valkey supported .-> EXTVK["valkey.external.enabled"]:::added
```

## Changes

### Chart surface

- `Chart.yaml`: bump `version 0.1.0 → 0.2.0`, `appVersion "1.0.0" → "1.1.0"` to match the image shipping Phase 2/3.
- `values.yaml`: restructured into infra blocks + one flat top-level `config:` block whose keys mirror the `src/config.ts` Zod schema 1:1. Every parameter has a single-line comment describing when to set it. Generic defaults only — no Longhorn, no real hostnames in the chart.
- `serviceAccount.automount` default flipped to `true` so isolated-job spawning works when `rbac.create: true`; stale RBAC comment fixed.

### New templates (all gated, default `enabled: false`)

- `role.yaml` + `rolebinding.yaml` — `batch/jobs` CRUD + `pods`,`pods/log` read on release namespace. Required by `src/k8s/job-spawner.ts`.
- `postgres-{statefulset,service,secret}.yaml` — 1-replica StatefulSet with `volumeClaimTemplates`, image `pgvector/pgvector:pg17` (pgvector-ready for Phase 6 semantic search). `existingSecret` / `existingClaim` escape hatches.
- `valkey-{deployment,service,secret,pvc}.yaml` — mirrors the `charts/mcp-server-boilerplate` house pattern. AUTH enforced via `--requirepass` on the server CLI.
- `shared-runner-{deployment,service}.yaml` — same webhook image with `INTERNAL_RUNNER=true`, `PORT=7081`. Forward-compatible: the app does not yet register `POST /internal/run`, so the template stays off by default.

### Helpers (`_helpers.tpl`)

- `databaseUrl` / `valkeyUrl` composers. Resolution order: literal override → in-chart service DNS → external host/port/credentials → empty.
- `stableToken` generator using `lookup "v1" "Secret" …`. Auto-generated `DAEMON_AUTH_TOKEN` / `INTERNAL_RUNNER_TOKEN` / `SHARED_RUNNER_TOKEN` and Postgres/Valkey passwords persist across `helm upgrade`.
- `config.existingSecret` escape hatch: one sealed Secret can own every sensitive key; chart skips rendering its own Secret when set.

### External Postgres / Valkey support

Three shapes supported:

| Scenario | Configuration |
|---|---|
| In-chart (recommended default) | `postgres.enabled: true`, `valkey.enabled: true` |
| External via field overrides | `postgres.external.enabled: true` + host/port/username/database/existingSecret |
| External, user-supplied URL | leave both off; set `config.databaseUrl` / `config.valkeyUrl` verbatim |

### Env-var coverage

Every `process.env.*` in `src/config.ts` is reachable via `helm upgrade --set config.<key>`. Routing to ConfigMap vs Secret is handled by a hardcoded sensitivity list in the templates.

### CI

- `.github/workflows/lint.yml` — five-scenario `helm template` render matrix (inline, bedrock, in-chart PG+Valkey+RBAC, external PG+Valkey, user-supplied URLs).
- `.github/workflows/release.yml` — pre-release gate that fails loudly if any `Chart.yaml` version already has a matching git tag. `skip_existing: true` on `chart-releaser-action` kept as a safety net.
- GitLab CI intentionally left unchanged (main-branch publish remains driven by GitHub `chart-releaser`).

## Verification

- `helm lint --strict charts/github-app-playground` — clean.
- `ct lint --config ct.yaml` — clean (chart-testing container).
- Five-scenario render matrix — all render.
- `kubectl apply --dry-run=client` — 6 resources on Phase 1 inline path, 17 on full Phase 4 path.
- Env-var coverage audited via `rg 'process\.env' src/config.ts`.

## Test plan

- [ ] GitHub Actions lint workflow passes
- [ ] GitLab CI publishes `0.2.0-dev-<sha>` to the chart registry
- [ ] Copilot review
- [ ] Coderabbit review

## Intentionally deferred

- `daemon-deployment.yaml`, HPA/PDB for new components, NetworkPolicy, Postgres HA.
- `CREATE EXTENSION vector` — Phase 6 migration.
- `argocd-apps` updates (sealed-secret keys, values override, `targetRevision` bump) — separate PR once this chart publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)