### PR TITLE
fix(ci): scope release gate to charts changed since their tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Verify chart versions are not already released
-        # Fail loudly if any chart's Chart.yaml version already has a matching
-        # <chart-name>-<version> git tag. chart-releaser's skip_existing would
-        # otherwise silently skip — which hides accidental no-op releases.
-        # Inputs are files + git tags only; no github.* context data is used.
+        # Fail if a chart's files changed since its current version tag without
+        # a version bump. Unchanged charts are skipped — chart-releaser will
+        # also skip them via skip_existing. Only checks charts that diverged
+        # from their tag, so unrelated merges don't break the gate.
         run: |
           set -euo pipefail
           fail=0
@@ -37,8 +37,11 @@ jobs:
             version=$(yq e '.version' "${chart_dir}Chart.yaml")
             tag="${name}-${version}"
             if git rev-parse "refs/tags/${tag}" >/dev/null 2>&1; then
-              echo "::error file=${chart_dir}Chart.yaml::tag ${tag} already exists - bump version before merging"
-              fail=1
+              changed=$(git diff --name-only "refs/tags/${tag}" HEAD -- "${chart_dir}")
+              if [ -n "$changed" ]; then
+                echo "::error file=${chart_dir}Chart.yaml::tag ${tag} already exists but chart has changed - bump version before merging"
+                fail=1
+              fi
             fi
           done
           if [ "$fail" -ne 0 ]; then


### PR DESCRIPTION
## Summary                                                                                                                                                                                                    
                                                                                                                                                                                                              
  The "Verify chart versions are not already released" gate in `release.yml` was introduced in #12 with a logic flaw: it checked **all** charts against existing git tags, not just charts modified in the current commit. Every push to `main` containing any chart change would immediately fail because the untouched charts' current versions already had matching tags — a condition that can never be resolved  without bumping every chart version on every PR.                              
                                                                                                                                                                                                                
  **Root cause:** the gate had no awareness of whether a chart had actually changed. A chart with `version: 0.1.3` and a `binance-trading-bot-0.1.3` tag is perfectly fine as long as no files under `charts/binance-trading-bot/` were modified.                                                                                                                                                                  
                                                                                                                                                                                                              
  **Fix:** add a `git diff --name-only <tag> HEAD -- <chart_dir>` check. The gate now only fails when a chart's files have changed since the existing version tag — i.e., the exact scenario where a version  bump is required.                                                                                                                                                                                           
                                                                                                                                                                                                                
  ### Before                                                                                                                                                                                                    
                                                                                
  ```mermaid                                                                                                                                                                                                    
  flowchart TD                                                                                                                                                                                                  
      CHK["For each chart"]:::step                                              
      TAG{"Tag exists?<br/>name-version"}:::decision                                                                                                                                                            
      FAIL["FAIL:<br/>tag already exists"]:::bad                         
      DONE["Pass"]:::good                                                       
                                                                                                                                                                                                                
      CHK --> TAG                                                                                                                                                                                               
      TAG -- yes --> FAIL                                                                                                                                                                                       
      TAG -- no --> DONE                                                                                                                                                                                        
                                                                                                                                                                                                                
      classDef step fill:#1e3a5f,color:#ffffff,stroke:#1e3a5f                                                                                                                                                 
      classDef decision fill:#4a2c00,color:#ffffff,stroke:#4a2c00                                                                                                                                             
      classDef bad fill:#7a0000,color:#ffffff,stroke:#7a0000                                                                                                                                                    
      classDef good fill:#1a4a1a,color:#ffffff,stroke:#1a4a1a
  ```
                                                                                                                                                                                                              
  After            
                                                      
  ```mermaid                                                                                                                                                                                                                
  flowchart TD                                                                                                                                                                                                  
      CHK["For each chart"]:::step                                                                                                                                                                              
      TAG{"Tag exists?<br/>name-version"}:::decision                                                                                                                                                            
      DIFF{"Files changed<br/>since tag?"}:::decision                           
      FAIL["FAIL:<br/>bump version before merging"]:::bad                                                                                                                                                     
      SKIP["SKIP:<br/>unchanged — chart-releaser<br/>will skip via skip_existing"]:::neutral                                                                                                                  
      DONE["Pass — release new version"]:::good
                                                                                                                                                                                                                
      CHK --> TAG
      TAG -- yes --> DIFF                                                                                                                                                                                       
      TAG -- no --> DONE                                                 
      DIFF -- yes --> FAIL                                                                                                                                                                                      
      DIFF -- no --> SKIP                                                                                                                                                                                     
                                                                                                                                                                                                                
      classDef step fill:#1e3a5f,color:#ffffff,stroke:#1e3a5f                                                                                                                                                 
      classDef decision fill:#4a2c00,color:#ffffff,stroke:#4a2c00                                                                                                                                               
      classDef bad fill:#7a0000,color:#ffffff,stroke:#7a0000             
      classDef neutral fill:#2a2a2a,color:#cccccc,stroke:#555555                                                                                                                                                
      classDef good fill:#1a4a1a,color:#ffffff,stroke:#1a4a1a                                                                                                                                                 
  ```
                                                                                                                                                                                                              
  Changes                                                                
                                                                                                                                                                                                                
  - .github/workflows/release.yml: replace unconditional tag-existence check with a two-step check — tag exists and chart files changed since that tag → fail; tag exists but chart unchanged → skip silently 
  - Updated step comment to accurately describe the new invariant         