### PR TITLE
feat(github-app-playground)!: split secrets: block from config: (breaking)

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/github-app-playground/templates/NOTES.txt
+++ b/charts/github-app-playground/templates/NOTES.txt
@@ -45,19 +45,52 @@
    kubectl --namespace {{ .Release.Namespace }} logs -f deploy/{{ include "github-app-playground.fullname" . }} \
      | jq 'select(.msg | test("dispatch decision|triage"))'
 
+UPGRADING from chart 0.2.x to 0.3.0 (breaking):
+   Chart 0.3.0 splits `config:` into two top-level blocks. Every sensitive
+   credential / token moved back out of `config:` into a dedicated `secrets:`
+   block so the secret boundary is structurally explicit in values.yaml.
+   `existingSecret` moved with them (it's the escape hatch *for* secrets).
+
+   Renames to apply to your override values before `helm upgrade`:
+     config.existingSecret          -> secrets.existingSecret
+     config.appId                   -> secrets.appId
+     config.privateKey              -> secrets.privateKey
+     config.webhookSecret           -> secrets.webhookSecret
+     config.anthropicApiKey         -> secrets.anthropicApiKey
+     config.claudeCodeOauthToken    -> secrets.claudeCodeOauthToken
+     config.awsAccessKeyId          -> secrets.awsAccessKeyId
+     config.awsSecretAccessKey      -> secrets.awsSecretAccessKey
+     config.awsSessionToken         -> secrets.awsSessionToken
+     config.awsBearerTokenBedrock   -> secrets.awsBearerTokenBedrock
+     config.context7ApiKey          -> secrets.context7ApiKey
+     config.internalRunnerToken     -> secrets.internalRunnerToken
+     config.sharedRunnerToken       -> secrets.sharedRunnerToken
+     config.daemonAuthToken         -> secrets.daemonAuthToken
+     config.databaseUrl             -> secrets.databaseUrl
+     config.valkeyUrl               -> secrets.valkeyUrl
+   Everything else stays under `config:`. Upgrading without renaming will
+   produce a Deployment that mounts no credentials and crashes at startup.
+
+   Recommended workflow: put non-sensitive overrides in a gitted values.yaml
+   and credentials in a gitignored secrets.yaml, then:
+     helm upgrade <release> <chart> --values values.yaml --values secrets.yaml
+   Or skip secrets.yaml entirely and set `secrets.existingSecret` to a Secret
+   managed by Sealed Secrets / External Secrets / SOPS / Vault.
+
 UPGRADING from chart 0.1.x:
    Chart 0.2.0 restructured values.yaml. The old `app:` and `secrets:` top-level
-   blocks are gone; every application knob now lives under `config:` (a flat 1:1
-   mirror of the app image's src/config.ts Zod schema). Renames you must apply
-   to your override values before `helm upgrade`:
+   blocks were replaced by a single `config:` block (a flat 1:1 mirror of the
+   app image's src/config.ts Zod schema). Chart 0.3.0 then re-split the secret
+   subset back out into `secrets:` — see the 0.2.x -> 0.3.0 section above for
+   the final paths. Going from 0.1.x directly to 0.3.0, apply these renames:
      app.port                 -> config.port
      app.cloneBaseDir         -> config.cloneBaseDir
      app.triggerPhrase        -> config.triggerPhrase
-     secrets.existingSecret   -> config.existingSecret
-     secrets.appId            -> config.appId
-     secrets.privateKey       -> config.privateKey
-     secrets.webhookSecret    -> config.webhookSecret
-     secrets.anthropicApiKey  -> config.anthropicApiKey
-     secrets.context7ApiKey   -> config.context7ApiKey
+     secrets.existingSecret   -> secrets.existingSecret (unchanged in 0.3.0)
+     secrets.appId            -> secrets.appId (unchanged in 0.3.0)
+     secrets.privateKey       -> secrets.privateKey (unchanged in 0.3.0)
+     secrets.webhookSecret    -> secrets.webhookSecret (unchanged in 0.3.0)
+     secrets.anthropicApiKey  -> secrets.anthropicApiKey (unchanged in 0.3.0)
+     secrets.context7ApiKey   -> secrets.context7ApiKey (unchanged in 0.3.0)
    Upgrading without renaming will produce a Deployment that mounts no
    credentials and crashes at startup.

--- a/charts/github-app-playground/templates/_helpers.tpl
+++ b/charts/github-app-playground/templates/_helpers.tpl
@@ -62,12 +62,12 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Name of the Secret holding app credentials. Uses config.existingSecret when set,
+Name of the Secret holding app credentials. Uses secrets.existingSecret when set,
 otherwise the chart-managed name <fullname>-secret.
 */}}
 {{- define "github-app-playground.secretName" -}}
-{{- if .Values.config.existingSecret }}
-{{- .Values.config.existingSecret }}
+{{- if .Values.secrets.existingSecret }}
+{{- .Values.secrets.existingSecret }}
 {{- else }}
 {{- printf "%s-secret" (include "github-app-playground.fullname" .) }}
 {{- end }}
@@ -205,15 +205,15 @@ Resolved external-Valkey password. Mirrors externalPostgresPassword.
 
 {{/*
 Composed DATABASE_URL. Resolution order (stops at first match):
-  1. config.databaseUrl (literal) → use verbatim.
+  1. secrets.databaseUrl (literal) → use verbatim.
   2. postgres.enabled=true        → postgresql://u:p@<fullname>-postgres:port/db?sslmode=disable
   3. postgres.external.enabled=true → postgresql://u:p@host:port/db?sslmode=<sslmode>
   4. nothing                      → empty string.
 Consumers: template that emits it skips writing the key when empty.
 */}}
 {{- define "github-app-playground.databaseUrl" -}}
-{{- if .Values.config.databaseUrl -}}
-{{- .Values.config.databaseUrl -}}
+{{- if .Values.secrets.databaseUrl -}}
+{{- .Values.secrets.databaseUrl -}}
 {{- else if .Values.postgres.enabled -}}
 {{- $pw := include "github-app-playground.postgresPassword" . -}}
 {{- printf "postgresql://%s:%s@%s-postgres:%d/%s?sslmode=disable" .Values.postgres.auth.username $pw (include "github-app-playground.fullname" .) (int .Values.postgres.service.port) .Values.postgres.auth.database -}}
@@ -227,8 +227,8 @@ Consumers: template that emits it skips writing the key when empty.
 Composed VALKEY_URL. Same resolution order as databaseUrl.
 */}}
 {{- define "github-app-playground.valkeyUrl" -}}
-{{- if .Values.config.valkeyUrl -}}
-{{- .Values.config.valkeyUrl -}}
+{{- if .Values.secrets.valkeyUrl -}}
+{{- .Values.secrets.valkeyUrl -}}
 {{- else if .Values.valkey.enabled -}}
 {{- $host := printf "%s-valkey" (include "github-app-playground.fullname" .) -}}
 {{- if .Values.valkey.auth.enabled -}}

--- a/charts/github-app-playground/templates/secret.yaml
+++ b/charts/github-app-playground/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.config.existingSecret }}
+{{- if not .Values.secrets.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,51 +9,51 @@ type: Opaque
 data:
   # Secret-bound env vars. Keys gated by `if` so only provided values render.
   # Field order mirrors the numbered groups in src/config.ts.
-  {{- $c := .Values.config }}
+  {{- $s := .Values.secrets }}
   {{- $fullname := include "github-app-playground.fullname" . }}
   {{- $appSecret := printf "%s-secret" $fullname }}
 
   # --- 1. GitHub App credentials --- (toString guards against --set passing a numeric appId)
-  {{- if $c.appId }}
-  GITHUB_APP_ID: {{ $c.appId | toString | b64enc | quote }}
+  {{- if $s.appId }}
+  GITHUB_APP_ID: {{ $s.appId | toString | b64enc | quote }}
   {{- end }}
-  {{- if $c.privateKey }}
-  GITHUB_APP_PRIVATE_KEY: {{ $c.privateKey | toString | b64enc | quote }}
+  {{- if $s.privateKey }}
+  GITHUB_APP_PRIVATE_KEY: {{ $s.privateKey | toString | b64enc | quote }}
   {{- end }}
-  {{- if $c.webhookSecret }}
-  GITHUB_WEBHOOK_SECRET: {{ $c.webhookSecret | toString | b64enc | quote }}
+  {{- if $s.webhookSecret }}
+  GITHUB_WEBHOOK_SECRET: {{ $s.webhookSecret | toString | b64enc | quote }}
   {{- end }}
 
   # --- 3. Anthropic direct-API credentials ---
-  {{- if $c.anthropicApiKey }}
-  ANTHROPIC_API_KEY: {{ $c.anthropicApiKey | b64enc | quote }}
+  {{- if $s.anthropicApiKey }}
+  ANTHROPIC_API_KEY: {{ $s.anthropicApiKey | b64enc | quote }}
   {{- end }}
-  {{- if $c.claudeCodeOauthToken }}
-  CLAUDE_CODE_OAUTH_TOKEN: {{ $c.claudeCodeOauthToken | b64enc | quote }}
+  {{- if $s.claudeCodeOauthToken }}
+  CLAUDE_CODE_OAUTH_TOKEN: {{ $s.claudeCodeOauthToken | b64enc | quote }}
   {{- end }}
 
   # --- 4. AWS Bedrock credentials (secret subset) ---
-  {{- if $c.awsAccessKeyId }}
-  AWS_ACCESS_KEY_ID: {{ $c.awsAccessKeyId | b64enc | quote }}
+  {{- if $s.awsAccessKeyId }}
+  AWS_ACCESS_KEY_ID: {{ $s.awsAccessKeyId | b64enc | quote }}
   {{- end }}
-  {{- if $c.awsSecretAccessKey }}
-  AWS_SECRET_ACCESS_KEY: {{ $c.awsSecretAccessKey | b64enc | quote }}
+  {{- if $s.awsSecretAccessKey }}
+  AWS_SECRET_ACCESS_KEY: {{ $s.awsSecretAccessKey | b64enc | quote }}
   {{- end }}
-  {{- if $c.awsSessionToken }}
-  AWS_SESSION_TOKEN: {{ $c.awsSessionToken | b64enc | quote }}
+  {{- if $s.awsSessionToken }}
+  AWS_SESSION_TOKEN: {{ $s.awsSessionToken | b64enc | quote }}
   {{- end }}
-  {{- if $c.awsBearerTokenBedrock }}
-  AWS_BEARER_TOKEN_BEDROCK: {{ $c.awsBearerTokenBedrock | b64enc | quote }}
+  {{- if $s.awsBearerTokenBedrock }}
+  AWS_BEARER_TOKEN_BEDROCK: {{ $s.awsBearerTokenBedrock | b64enc | quote }}
   {{- end }}
 
   # --- 5. App runtime / behaviour (secret subset) ---
-  {{- if $c.context7ApiKey }}
-  CONTEXT7_API_KEY: {{ $c.context7ApiKey | b64enc | quote }}
+  {{- if $s.context7ApiKey }}
+  CONTEXT7_API_KEY: {{ $s.context7ApiKey | b64enc | quote }}
   {{- end }}
 
   # --- 8. Shared-runner HTTP target (auto-generated, stable via `lookup`) ---
-  INTERNAL_RUNNER_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "INTERNAL_RUNNER_TOKEN" "secretName" $appSecret "override" $c.internalRunnerToken "root" .) | b64enc | quote }}
-  SHARED_RUNNER_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "SHARED_RUNNER_TOKEN" "secretName" $appSecret "override" $c.sharedRunnerToken "root" .) | b64enc | quote }}
+  INTERNAL_RUNNER_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "INTERNAL_RUNNER_TOKEN" "secretName" $appSecret "override" $s.internalRunnerToken "root" .) | b64enc | quote }}
+  SHARED_RUNNER_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "SHARED_RUNNER_TOKEN" "secretName" $appSecret "override" $s.sharedRunnerToken "root" .) | b64enc | quote }}
 
   # --- 9. Data layer (auto-composed URLs from postgres.* / valkey.* resolution order) ---
   {{- $dbUrl := include "github-app-playground.databaseUrl" . }}
@@ -66,5 +66,5 @@ data:
   {{- end }}
 
   # --- 11. Daemon / Orchestrator WebSocket (auto-generated, stable via `lookup`) ---
-  DAEMON_AUTH_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "DAEMON_AUTH_TOKEN" "secretName" $appSecret "override" $c.daemonAuthToken "root" .) | b64enc | quote }}
+  DAEMON_AUTH_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "DAEMON_AUTH_TOKEN" "secretName" $appSecret "override" $s.daemonAuthToken "root" .) | b64enc | quote }}
 {{- end }}

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -315,7 +315,7 @@ config:
 
   # --- 4. AWS Bedrock credentials (non-secret subset) ---
   awsRegion: ""                                 # Required when provider=bedrock.
-  awsProfile: ""                                # Set only for local SSO (e.g. le aws login).
+  awsProfile: ""                                # Set only for local SSO (e.g. after `aws sso login`).
   anthropicBedrockBaseUrl: ""                   # Override only to front Bedrock with a VPC endpoint / proxy.
 
   # --- 5. App runtime / behaviour ---

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -257,38 +257,68 @@ sharedRunner:
   tolerations: []
   affinity: {}
 
-# ─────────────────────────── APPLICATION CONFIG ───────────────────────
-# `config:` is a flat 1:1 mirror of the Zod schema in the app image's
-# `src/config.ts`. Field names and group order match the numbered
-# sections of that schema. The chart routes each key to ConfigMap or
-# Secret based on a hardcoded sensitivity list in the templates.
-config:
-  existingSecret: ""                            # Chart-level escape hatch. When set, chart-managed Secret is not rendered.
+# ─────────────────────────── APPLICATION SECRETS ──────────────────────
+# `secrets:` holds every credential / token that is sensitive. These fields
+# are rendered into the chart-managed Kubernetes Secret and injected via
+# `envFrom: secretRef`. Section numbers mirror the groups in the app's
+# `src/config.ts` Zod schema (same ordering as `config:` below).
+#
+# NEVER commit real values here. Either:
+#   1) supply them via an out-of-repo, gitignored values file
+#      (`helm install ... --values secrets.yaml`), OR
+#   2) set `secrets.existingSecret` to the name of a pre-existing Secret
+#      managed by Sealed Secrets / External Secrets / SOPS / Vault.
+secrets:
+  # Chart escape hatch. When set, the chart-managed Secret is NOT rendered
+  # and the Deployment consumes the named Secret directly. All-or-nothing:
+  # the named Secret must contain every key the app expects (see secret.yaml).
+  existingSecret: ""
 
   # --- 1. GitHub App credentials (server mode) ---
   appId: ""                                     # Required in server mode (orchestratorUrl unset).
   privateKey: ""                                # PEM contents, not a file path.
   webhookSecret: ""
 
-  # --- 2. AI provider selection ---
-  provider: anthropic                           # anthropic | bedrock.
-  model: ""                                     # Required when provider=bedrock.
-
   # --- 3. Anthropic direct-API credentials ---
-  anthropicApiKey: ""                           # Required when provider=anthropic and claudeCodeOauthToken is empty.
-  claudeCodeOauthToken: ""                      # Alternative to anthropicApiKey. Requires allowedOwners.
+  anthropicApiKey: ""                           # Required when config.provider=anthropic and claudeCodeOauthToken is empty.
+  claudeCodeOauthToken: ""                      # Alternative to anthropicApiKey. Requires config.allowedOwners.
 
-  # --- 4. AWS Bedrock credentials ---
-  awsRegion: ""                                 # Required when provider=bedrock.
-  awsProfile: ""                                # Set only for local SSO (e.g. le aws login).
+  # --- 4. AWS Bedrock credentials (secret subset) ---
   awsAccessKeyId: ""                            # Set for static AWS creds; otherwise leave empty.
   awsSecretAccessKey: ""
   awsSessionToken: ""                           # Set for temporary AWS STS creds.
   awsBearerTokenBedrock: ""                     # Set to use Bedrock bearer-token auth (GitHub Actions OIDC).
+
+  # --- 5. App runtime / behaviour (secret subset) ---
+  context7ApiKey: ""                            # Lifts the Context7 MCP rate limit. Unset works.
+
+  # --- 8. Shared-runner HTTP target (auto-generated, persisted across upgrades) ---
+  internalRunnerToken: ""                       # Leave empty to auto-generate and persist.
+  sharedRunnerToken: ""                         # ADR-011 reserved; leave empty to auto-generate.
+
+  # --- 9. Data layer (connection strings embed passwords → secret, not config) ---
+  databaseUrl: ""                               # Leave empty to compose from postgres.* or postgres.external.*.
+  valkeyUrl: ""                                 # Leave empty to compose from valkey.* or valkey.external.*.
+
+  # --- 11. Daemon / Orchestrator WebSocket (auto-generated, persisted across upgrades) ---
+  daemonAuthToken: ""                           # Leave empty to auto-generate and persist.
+
+# ─────────────────────────── APPLICATION CONFIG ───────────────────────
+# `config:` is a 1:1 mirror of the non-secret fields of the Zod schema in
+# the app image's `src/config.ts`. Field names and group order match the
+# numbered sections of that schema. Every key here is rendered into the
+# chart-managed ConfigMap. Credentials live in `secrets:` above.
+config:
+  # --- 2. AI provider selection ---
+  provider: anthropic                           # anthropic | bedrock.
+  model: ""                                     # Required when provider=bedrock.
+
+  # --- 4. AWS Bedrock credentials (non-secret subset) ---
+  awsRegion: ""                                 # Required when provider=bedrock.
+  awsProfile: ""                                # Set only for local SSO (e.g. le aws login).
   anthropicBedrockBaseUrl: ""                   # Override only to front Bedrock with a VPC endpoint / proxy.
 
   # --- 5. App runtime / behaviour ---
-  context7ApiKey: ""                            # Lifts the Context7 MCP rate limit. Unset works.
   cloneBaseDir: /tmp/bot-workspaces             # Must match workspace.persistence mount path.
   cloneDepth: 50                                # Git shallow-clone depth.
   triggerPhrase: "@chrisleekr-bot"              # Must match the GitHub App's bot login exactly.
@@ -299,7 +329,7 @@ config:
   agentTimeoutMs: 600000
   agentMaxTurns: ""                             # Leave empty to use defaultMaxTurns or triage-derived turns.
   claudeCodePath: ""                            # Required only when claude-code is installed globally (e.g. Docker).
-  allowedOwners: ""                             # Comma-separated. Required when claudeCodeOauthToken is set.
+  allowedOwners: ""                             # Comma-separated. Required when secrets.claudeCodeOauthToken is set.
 
   # --- 6. Dispatch mode (Phase 2+ / Phase 3) ---
   agentJobMode: inline                          # inline | daemon | shared-runner | isolated-job | auto.
@@ -312,21 +342,14 @@ config:
   jobActiveDeadlineSeconds: 1800                # Zod caps at 3500 (installation-token TTL margin).
   jobWatchPollIntervalMs: 5000
 
-  # --- 8. Shared-runner HTTP target ---
+  # --- 8. Shared-runner HTTP target (non-secret subset) ---
   internalRunnerUrl: ""                         # Required when agentJobMode is shared-runner or auto.
-  internalRunnerToken: ""                       # Leave empty to auto-generate and persist.
-  sharedRunnerToken: ""                         # ADR-011 reserved; leave empty to auto-generate.
-
-  # --- 9. Data layer (required when agentJobMode is not inline) ---
-  valkeyUrl: ""                                 # Leave empty to compose from valkey.* or valkey.external.*.
-  databaseUrl: ""                               # Leave empty to compose from postgres.* or postgres.external.*.
 
   # --- 10. Orchestrator ---
   wsPort: 3002                                  # Must differ from config.port.
   jobMaxCostUsd: 80                             # Placeholder today (not enforced in code).
 
-  # --- 11. Daemon / Orchestrator WebSocket (Phase 2) ---
-  daemonAuthToken: ""                           # Leave empty to auto-generate and persist.
+  # --- 11. Daemon / Orchestrator WebSocket (non-secret subset) ---
   orchestratorUrl: ""                           # Setting this flips the process to DAEMON mode (webhook HTTP not started).
   heartbeatIntervalMs: 30000
   heartbeatTimeoutMs: 90000                     # Keep >= 2 x heartbeatIntervalMs.


### PR DESCRIPTION
## Summary

Chart **0.3.0** promotes every credential / token (and the `existingSecret` escape hatch) out of `config:` into a dedicated top-level `secrets:` block in `values.yaml`. The secret boundary is now structurally explicit in the values file rather than just enforced at template-render time.

**Why this matters.** In 0.2.x, fields like `anthropicApiKey`, `privateKey`, `claudeCodeOauthToken`, and the AWS credentials sat as plaintext placeholders inside `config:`. Nothing stopped a user from filling them in and committing the file, leaking API keys to git history. Runtime separation into a `Secret` resource already worked correctly, but the **authoring surface** invited misuse.

**What changes.** Layout only — runtime behavior is identical:

- Secret fields → chart-managed `Secret` (unchanged).
- Non-secret fields → chart-managed `ConfigMap` (unchanged).
- `secrets.existingSecret` now drives the all-or-nothing escape hatch (was `config.existingSecret`). This matches Bitnami's `auth.existingSecret` convention where the flag lives alongside the credentials it replaces.
- `stableToken` helper path (`<fullname>-secret`) is unchanged, so auto-generated `INTERNAL_RUNNER_TOKEN`, `SHARED_RUNNER_TOKEN`, and `DAEMON_AUTH_TOKEN` persist across 0.2.x → 0.3.0 upgrades via `lookup`.

### Before: values.yaml structure in 0.2.x

```mermaid
flowchart LR
    classDef mixed fill:#fde2cf,stroke:#7a3e00,color:#1a1a1a
    classDef leak fill:#f8d7da,stroke:#8a1c27,color:#1a1a1a

    Values["values.yaml"]:::mixed
    ConfigBlock["config:<br/>existingSecret<br/>appId / privateKey / webhookSecret<br/>anthropicApiKey / claudeCodeOauthToken<br/>awsAccessKeyId / awsSecretAccessKey<br/>awsSessionToken / awsBearerTokenBedrock<br/>context7ApiKey<br/>internalRunnerToken / sharedRunnerToken<br/>daemonAuthToken<br/>databaseUrl / valkeyUrl<br/>provider / awsRegion / port / logLevel<br/>agentJobMode / triageModel / ..."]:::leak

    Values --> ConfigBlock
```

### After: values.yaml structure in 0.3.0

```mermaid
flowchart LR
    classDef sec fill:#d1ecf1,stroke:#0c5460,color:#1a1a1a
    classDef cfg fill:#d4edda,stroke:#155724,color:#1a1a1a
    classDef root fill:#e2e3e5,stroke:#383d41,color:#1a1a1a

    Values["values.yaml"]:::root
    SecretsBlock["secrets:<br/>existingSecret<br/>appId / privateKey / webhookSecret<br/>anthropicApiKey / claudeCodeOauthToken<br/>awsAccessKeyId / awsSecretAccessKey<br/>awsSessionToken / awsBearerTokenBedrock<br/>context7ApiKey<br/>internalRunnerToken / sharedRunnerToken<br/>daemonAuthToken<br/>databaseUrl / valkeyUrl"]:::sec
    ConfigBlock["config:<br/>provider / model<br/>awsRegion / awsProfile / anthropicBedrockBaseUrl<br/>cloneBaseDir / port / logLevel<br/>agentJobMode / defaultDispatchTarget<br/>jobNamespace / jobImage / jobTtlSeconds<br/>internalRunnerUrl<br/>orchestratorUrl / heartbeatIntervalMs<br/>triageModel / defaultMaxTurns<br/>maxConcurrentIsolatedJobs / ..."]:::cfg

    Values --> SecretsBlock
    Values --> ConfigBlock
```

## Breaking changes

Chart 0.3.0 is a breaking values-file migration. Rename these paths in your override values **before** `helm upgrade`:

| 0.2.x path                        | 0.3.0 path                          |
| --------------------------------- | ----------------------------------- |
| `config.existingSecret`           | `secrets.existingSecret`            |
| `config.appId`                    | `secrets.appId`                     |
| `config.privateKey`               | `secrets.privateKey`                |
| `config.webhookSecret`            | `secrets.webhookSecret`             |
| `config.anthropicApiKey`          | `secrets.anthropicApiKey`           |
| `config.claudeCodeOauthToken`     | `secrets.claudeCodeOauthToken`      |
| `config.awsAccessKeyId`           | `secrets.awsAccessKeyId`            |
| `config.awsSecretAccessKey`       | `secrets.awsSecretAccessKey`        |
| `config.awsSessionToken`          | `secrets.awsSessionToken`           |
| `config.awsBearerTokenBedrock`    | `secrets.awsBearerTokenBedrock`     |
| `config.context7ApiKey`           | `secrets.context7ApiKey`            |
| `config.internalRunnerToken`      | `secrets.internalRunnerToken`       |
| `config.sharedRunnerToken`        | `secrets.sharedRunnerToken`         |
| `config.daemonAuthToken`          | `secrets.daemonAuthToken`           |
| `config.databaseUrl`              | `secrets.databaseUrl`               |
| `config.valkeyUrl`                | `secrets.valkeyUrl`                 |

Upgrading without renaming produces a Deployment that mounts an empty chart-managed Secret — the pod will crash at startup rather than silently using stale creds. `NOTES.txt` prints the full rename table on every `helm install` / `helm upgrade`.

**Recommended workflow:**
```bash
# Public, gitted: values.yaml  (no credentials)
# Private, gitignored: secrets.yaml  (literal credentials)
helm upgrade gap charts/github-app-playground \
  --values values.yaml \
  --values secrets.yaml
```
Or skip the secrets file entirely and set `secrets.existingSecret` to a Secret managed by Sealed Secrets / External Secrets / SOPS / Vault.

## Changes

- `charts/github-app-playground/values.yaml` — added top-level `secrets:` block containing `existingSecret` + 15 credentials/tokens; removed those same keys from `config:`; refreshed inline guidance comments to point to the new workflow.
- `charts/github-app-playground/templates/secret.yaml` — switched `$c := .Values.config` → `$s := .Values.secrets`; updated every field reference and the `if not ... existingSecret` top-level guard.
- `charts/github-app-playground/templates/_helpers.tpl` — updated `secretName` helper to read `.Values.secrets.existingSecret`; updated `databaseUrl` / `valkeyUrl` composer literal-override paths to `.Values.secrets.databaseUrl` / `.Values.secrets.valkeyUrl`.
- `charts/github-app-playground/templates/NOTES.txt` — added a 0.2.x → 0.3.0 upgrade section with the full rename table and recommended two-file workflow; kept the 0.1.x section for multi-hop upgrades.
- `charts/github-app-playground/Chart.yaml` — bumped `version` to `0.3.0`.
- No changes to `configmap.yaml`, `deployment.yaml`, or any sidecar (postgres / valkey / shared-runner / RBAC) templates — the Deployment's `secretRef` resolves through `include "github-app-playground.secretName"`, which already picks up the new path via the helper.

## Test plan

- [x] `helm lint --strict` passes across all 5 scenarios.
- [x] 5-scenario render matrix (defaults / literal secrets / `secrets.existingSecret` / embedded pg+valkey / external pg+valkey via `secrets.*`) all render and pass `kubectl apply --dry-run=client`.
- [x] Rendered `ConfigMap` portion of every scenario contains zero credential keys (grep confirms no `ANTHROPIC_API_KEY` / `PRIVATE_KEY` / `AWS_SECRET_ACCESS_KEY` / `DATABASE_URL` / `VALKEY_URL` / etc. leaks).
- [x] Scenario 3 (`secrets.existingSecret: "my-external-secret"`) produces zero chart-managed `Secret` resources and points the Deployment's `secretRef` at the named external Secret.
- [x] Scenario 4 (embedded) correctly composes `DATABASE_URL` with the embedded-pg password and `VALKEY_URL` with the literal Valkey password.
- [x] `stableToken` helper path (`<fullname>-secret`) and key names are unchanged → auto-generated tokens persist across 0.2.x → 0.3.0 upgrades via `lookup`.
- [ ] Live cluster upgrade test (0.2.0 → 0.3.0) — optional, deferred until next release cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)