### PR TITLE
feat(github-app-playground): add named daemon pool support with DinD sidecar (v0.4.0)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,3 +59,6 @@ jobs:
             --set config.databaseUrl=postgres://u:p@h/d \
             --set config.valkeyUrl=redis://h:6379 \
             --set config.agentJobMode=daemon > /dev/null
+          # 6. Daemon pools: default (no DinD) + docker-heavy (rootless DinD).
+          helm template "$chart" \
+            --values "$chart/ci/daemon-pools-values.yaml" > /dev/null

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "automount",
     "chrislee",
     "chrisleekr",
+    "dind",
     "geolocation",
     "healthz",
     "interruptible",

--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/github-app-playground/ci/daemon-pools-values.yaml
+++ b/charts/github-app-playground/ci/daemon-pools-values.yaml
@@ -1,0 +1,31 @@
+config:
+  agentJobMode: daemon
+
+postgres:
+  enabled: true
+
+valkey:
+  enabled: true
+
+daemon:
+  pools:
+    default:
+      replicaCount: 2
+      resources:
+        requests:
+          cpu: 250m
+          memory: 256Mi
+        limits:
+          cpu: 1000m
+          memory: 1Gi
+    docker-heavy:
+      replicaCount: 1
+      resources:
+        requests:
+          cpu: 500m
+          memory: 512Mi
+        limits:
+          cpu: 2000m
+          memory: 2Gi
+      dind:
+        enabled: true

--- a/charts/github-app-playground/templates/NOTES.txt
+++ b/charts/github-app-playground/templates/NOTES.txt
@@ -70,6 +70,10 @@ UPGRADING from chart 0.3.x to 0.4.0:
    Non-breaking: daemon.pools defaults to {} (no daemon Deployments).
    The orchestrator Service gains a `ws` port (config.wsPort, default 3002)
    only when config.agentJobMode is non-inline or daemon.pools is non-empty.
+   The Service selector now includes app.kubernetes.io/component: orchestrator;
+   helm upgrade restarts orchestrator pods with the new label automatically.
+   If you restrict pod ingress via NetworkPolicy, add a rule permitting traffic
+   on the ws port (config.wsPort, default 3002) when using non-inline mode.
    No existing values need to change.
 
 UPGRADING from chart 0.2.x to 0.3.0 (breaking):

--- a/charts/github-app-playground/templates/NOTES.txt
+++ b/charts/github-app-playground/templates/NOTES.txt
@@ -45,6 +45,33 @@
    kubectl --namespace {{ .Release.Namespace }} logs -f deploy/{{ include "github-app-playground.fullname" . }} \
      | jq 'select(.msg | test("dispatch decision|triage"))'
 
+DAEMON POOLS (config.agentJobMode must be daemon, shared-runner, or auto):
+   Deploy one or more stateless daemon pools alongside the orchestrator:
+
+     daemon:
+       pools:
+         default:
+           replicaCount: 2
+         docker-heavy:          # pool with Docker-in-Docker sidecar
+           replicaCount: 1
+           dind:
+             enabled: true
+
+   Each pool renders a separate Deployment named <fullname>-daemon-<pool>.
+   Verify daemons registered:
+     kubectl --namespace {{ .Release.Namespace }} logs \
+       -l "app.kubernetes.io/component=daemon" \
+       | grep 'daemon:registered'
+
+   Required: Postgres + Valkey must be reachable (postgres.enabled / valkey.enabled
+   or external) when agentJobMode is non-inline.
+
+UPGRADING from chart 0.3.x to 0.4.0:
+   Non-breaking: daemon.pools defaults to {} (no daemon Deployments).
+   The orchestrator Service gains a `ws` port (config.wsPort, default 3002)
+   only when config.agentJobMode is non-inline or daemon.pools is non-empty.
+   No existing values need to change.
+
 UPGRADING from chart 0.2.x to 0.3.0 (breaking):
    Chart 0.3.0 splits `config:` into two top-level blocks. Every sensitive
    credential / token moved back out of `config:` into a dedicated `secrets:`

--- a/charts/github-app-playground/templates/NOTES.txt
+++ b/charts/github-app-playground/templates/NOTES.txt
@@ -60,6 +60,7 @@ DAEMON POOLS (config.agentJobMode must be daemon, shared-runner, or auto):
    Each pool renders a separate Deployment named <fullname>-daemon-<pool>.
    Verify daemons registered:
      kubectl --namespace {{ .Release.Namespace }} logs \
+       -c daemon \
        -l "app.kubernetes.io/component=daemon" \
        | grep 'daemon:registered'
 

--- a/charts/github-app-playground/templates/_helpers.tpl
+++ b/charts/github-app-playground/templates/_helpers.tpl
@@ -224,6 +224,59 @@ Consumers: template that emits it skips writing the key when empty.
 {{- end }}
 
 {{/*
+─────────────────────────── DAEMON POOL HELPERS ───────────────────────────
+*/}}
+
+{{/*
+Daemon pool fully-qualified name: <fullname>-daemon-<poolName>, truncated to 63 chars.
+Args (dict): root (.), poolName (string).
+*/}}
+{{- define "github-app-playground.daemon.fullname" -}}
+{{- printf "%s-daemon-%s" (include "github-app-playground.fullname" .root) .poolName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Daemon pool selector labels. Extends base selectorLabels with component + pool.
+Args (dict): root (.), poolName (string).
+*/}}
+{{- define "github-app-playground.daemon.selectorLabels" -}}
+{{- include "github-app-playground.selectorLabels" .root }}
+app.kubernetes.io/component: daemon
+app.kubernetes.io/pool: {{ .poolName }}
+{{- end }}
+
+{{/*
+Daemon pool service account name.
+Resolution: pool.serviceAccount.name → daemon.serviceAccount.name → orchestrator SA name.
+Args (dict): root (.), pool (pool spec).
+*/}}
+{{- define "github-app-playground.daemon.serviceAccountName" -}}
+{{- $poolSA := .pool.serviceAccount | default dict }}
+{{- if $poolSA.name }}
+{{- $poolSA.name }}
+{{- else if .root.Values.daemon.serviceAccount.name }}
+{{- .root.Values.daemon.serviceAccount.name }}
+{{- else }}
+{{- include "github-app-playground.serviceAccountName" .root }}
+{{- end }}
+{{- end }}
+
+{{/*
+ORCHESTRATOR_URL for a daemon pool.
+Resolution: pool.orchestratorUrl → daemon.orchestratorUrl → ws://<fullname>:<wsPort>/ws.
+Args (dict): root (.), pool (pool spec).
+*/}}
+{{- define "github-app-playground.daemon.orchestratorUrl" -}}
+{{- if .pool.orchestratorUrl }}
+{{- .pool.orchestratorUrl }}
+{{- else if .root.Values.daemon.orchestratorUrl }}
+{{- .root.Values.daemon.orchestratorUrl }}
+{{- else }}
+{{- printf "ws://%s:%v/ws" (include "github-app-playground.fullname" .root) .root.Values.config.wsPort }}
+{{- end }}
+{{- end }}
+
+{{/*
 Composed VALKEY_URL. Same resolution order as databaseUrl.
 */}}
 {{- define "github-app-playground.valkeyUrl" -}}

--- a/charts/github-app-playground/templates/_helpers.tpl
+++ b/charts/github-app-playground/templates/_helpers.tpl
@@ -228,11 +228,15 @@ Consumers: template that emits it skips writing the key when empty.
 */}}
 
 {{/*
-Daemon pool fully-qualified name: <fullname>-daemon-<poolName>, truncated to 63 chars.
+Daemon pool fully-qualified name: <fullname>-daemon-<poolName>, max 63 chars.
+The pool suffix is preserved by truncating the base to fit, preventing collisions
+when a long release name would push two different pool names to the same string.
 Args (dict): root (.), poolName (string).
 */}}
 {{- define "github-app-playground.daemon.fullname" -}}
-{{- printf "%s-daemon-%s" (include "github-app-playground.fullname" .root) .poolName | trunc 63 | trimSuffix "-" }}
+{{- $suffix := printf "-daemon-%s" .poolName -}}
+{{- $base := include "github-app-playground.fullname" .root | trunc (int (sub 63 (len $suffix))) | trimSuffix "-" -}}
+{{- printf "%s%s" $base $suffix | trimSuffix "-" -}}
 {{- end }}
 
 {{/*

--- a/charts/github-app-playground/templates/configmap.yaml
+++ b/charts/github-app-playground/templates/configmap.yaml
@@ -72,7 +72,7 @@ data:
 
   # --- 11. Daemon / Orchestrator WebSocket ---
   {{- if $c.orchestratorUrl }}
-  ORCHESTRATOR_URL: {{ $c.orchestratorUrl | quote }}
+  {{- fail "config.orchestratorUrl must not be set on the orchestrator — presence of ORCHESTRATOR_URL flips it into daemon mode. Use daemon.orchestratorUrl or per-pool pools.<name>.orchestratorUrl instead." }}
   {{- end }}
   HEARTBEAT_INTERVAL_MS: {{ $c.heartbeatIntervalMs | quote }}
   HEARTBEAT_TIMEOUT_MS: {{ $c.heartbeatTimeoutMs | quote }}

--- a/charts/github-app-playground/templates/configmap.yaml
+++ b/charts/github-app-playground/templates/configmap.yaml
@@ -72,7 +72,7 @@ data:
 
   # --- 11. Daemon / Orchestrator WebSocket ---
   {{- if $c.orchestratorUrl }}
-  {{- fail "config.orchestratorUrl must not be set on the orchestrator — presence of ORCHESTRATOR_URL flips it into daemon mode. Use daemon.orchestratorUrl or per-pool pools.<name>.orchestratorUrl instead." }}
+  {{- fail "config.orchestratorUrl must not be set on the orchestrator — presence of ORCHESTRATOR_URL flips it into daemon mode. Use daemon.orchestratorUrl or per-pool daemon.pools.<name>.orchestratorUrl instead." }}
   {{- end }}
   HEARTBEAT_INTERVAL_MS: {{ $c.heartbeatIntervalMs | quote }}
   HEARTBEAT_TIMEOUT_MS: {{ $c.heartbeatTimeoutMs | quote }}

--- a/charts/github-app-playground/templates/daemon-deployment.yaml
+++ b/charts/github-app-playground/templates/daemon-deployment.yaml
@@ -2,19 +2,25 @@
 {{- if ne ($pool.enabled | toString) "false" }}
 {{- $poolCfg := $pool.config | default dict }}
 {{- $daemonCfg := $.Values.daemon.config }}
-{{- $drainMs := int ($poolCfg.daemonDrainTimeoutMs | default $daemonCfg.daemonDrainTimeoutMs) }}
+{{- $drainMs := int (ternary $poolCfg.daemonDrainTimeoutMs $daemonCfg.daemonDrainTimeoutMs (hasKey $poolCfg "daemonDrainTimeoutMs")) }}
 {{- $gracePeriod := "" }}
-{{- if $pool.terminationGracePeriodSeconds }}
+{{- if ne ($pool.terminationGracePeriodSeconds | toString) "" }}
 {{- $gracePeriod = $pool.terminationGracePeriodSeconds }}
-{{- else if $.Values.daemon.terminationGracePeriodSeconds }}
+{{- else if ne ($.Values.daemon.terminationGracePeriodSeconds | toString) "" }}
 {{- $gracePeriod = $.Values.daemon.terminationGracePeriodSeconds }}
 {{- else }}
 {{- $gracePeriod = add (div $drainMs 1000) 30 }}
 {{- end }}
 {{- $dindDefaults := $.Values.daemon.dind | default dict }}
 {{- $poolDind := $pool.dind | default dict }}
-{{- $dindEnabled := $poolDind.enabled | default $dindDefaults.enabled | default false }}
-{{- $rootless := $poolDind.rootless | default $dindDefaults.rootless | default true }}
+{{- $dindEnabled := false }}
+{{- if hasKey $poolDind "enabled" }}{{- $dindEnabled = $poolDind.enabled }}
+{{- else if hasKey $dindDefaults "enabled" }}{{- $dindEnabled = $dindDefaults.enabled }}
+{{- end }}
+{{- $rootless := true }}
+{{- if hasKey $poolDind "rootless" }}{{- $rootless = $poolDind.rootless }}
+{{- else if hasKey $dindDefaults "rootless" }}{{- $rootless = $dindDefaults.rootless }}
+{{- end }}
 {{- $dindStorageDefaults := $dindDefaults.storage | default dict }}
 {{- $dindStoragePool := $poolDind.storage | default dict }}
 {{- $dindStorageType := $dindStoragePool.type | default $dindStorageDefaults.type | default "emptyDir" }}
@@ -64,7 +70,11 @@ spec:
       terminationGracePeriodSeconds: {{ $gracePeriod }}
       containers:
         - name: daemon
-          {{- with ($pool.securityContext | default dict) }}
+          {{- $secCtx := $pool.securityContext | default dict }}
+          {{- if and $dindEnabled $rootless }}
+          {{-   $secCtx = mergeOverwrite (dict "runAsUser" 1000 "runAsGroup" 1000) $secCtx }}
+          {{- end }}
+          {{- with $secCtx }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -85,6 +95,7 @@ spec:
                 configMapKeyRef:
                   name: {{ include "github-app-playground.fullname" $ }}-config
                   key: CLAUDE_PROVIDER
+                  optional: true
             - name: CLAUDE_MODEL
               valueFrom:
                 configMapKeyRef:
@@ -96,44 +107,48 @@ spec:
                 configMapKeyRef:
                   name: {{ include "github-app-playground.fullname" $ }}-config
                   key: LOG_LEVEL
+                  optional: true
             - name: NODE_ENV
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "github-app-playground.fullname" $ }}-config
                   key: NODE_ENV
+                  optional: true
             - name: CLONE_BASE_DIR
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "github-app-playground.fullname" $ }}-config
                   key: CLONE_BASE_DIR
+                  optional: true
             - name: AGENT_TIMEOUT_MS
               valueFrom:
                 configMapKeyRef:
                   name: {{ include "github-app-playground.fullname" $ }}-config
                   key: AGENT_TIMEOUT_MS
+                  optional: true
             # Daemon-only knobs: pool override → cross-pool daemon.config default
             - name: HEARTBEAT_INTERVAL_MS
-              value: {{ $poolCfg.heartbeatIntervalMs | default $daemonCfg.heartbeatIntervalMs | quote }}
+              value: {{ ternary $poolCfg.heartbeatIntervalMs $daemonCfg.heartbeatIntervalMs (hasKey $poolCfg "heartbeatIntervalMs") | quote }}
             - name: HEARTBEAT_TIMEOUT_MS
-              value: {{ $poolCfg.heartbeatTimeoutMs | default $daemonCfg.heartbeatTimeoutMs | quote }}
+              value: {{ ternary $poolCfg.heartbeatTimeoutMs $daemonCfg.heartbeatTimeoutMs (hasKey $poolCfg "heartbeatTimeoutMs") | quote }}
             - name: STALE_EXECUTION_THRESHOLD_MS
-              value: {{ $poolCfg.staleExecutionThresholdMs | default $daemonCfg.staleExecutionThresholdMs | quote }}
+              value: {{ ternary $poolCfg.staleExecutionThresholdMs $daemonCfg.staleExecutionThresholdMs (hasKey $poolCfg "staleExecutionThresholdMs") | quote }}
             - name: DAEMON_DRAIN_TIMEOUT_MS
               value: {{ $drainMs | quote }}
             - name: JOB_MAX_RETRIES
-              value: {{ $poolCfg.jobMaxRetries | default $daemonCfg.jobMaxRetries | quote }}
+              value: {{ ternary $poolCfg.jobMaxRetries $daemonCfg.jobMaxRetries (hasKey $poolCfg "jobMaxRetries") | quote }}
             - name: OFFER_TIMEOUT_MS
-              value: {{ $poolCfg.offerTimeoutMs | default $daemonCfg.offerTimeoutMs | quote }}
+              value: {{ ternary $poolCfg.offerTimeoutMs $daemonCfg.offerTimeoutMs (hasKey $poolCfg "offerTimeoutMs") | quote }}
             - name: DAEMON_UPDATE_STRATEGY
-              value: {{ $poolCfg.daemonUpdateStrategy | default $daemonCfg.daemonUpdateStrategy | quote }}
+              value: {{ ternary $poolCfg.daemonUpdateStrategy $daemonCfg.daemonUpdateStrategy (hasKey $poolCfg "daemonUpdateStrategy") | quote }}
             - name: DAEMON_UPDATE_DELAY_MS
-              value: {{ $poolCfg.daemonUpdateDelayMs | default $daemonCfg.daemonUpdateDelayMs | quote }}
+              value: {{ ternary $poolCfg.daemonUpdateDelayMs $daemonCfg.daemonUpdateDelayMs (hasKey $poolCfg "daemonUpdateDelayMs") | quote }}
             - name: DAEMON_EPHEMERAL
-              value: {{ $poolCfg.daemonEphemeral | default $daemonCfg.daemonEphemeral | quote }}
+              value: {{ ternary $poolCfg.daemonEphemeral $daemonCfg.daemonEphemeral (hasKey $poolCfg "daemonEphemeral") | quote }}
             - name: DAEMON_MEMORY_FLOOR_MB
-              value: {{ $poolCfg.daemonMemoryFloorMb | default $daemonCfg.daemonMemoryFloorMb | quote }}
+              value: {{ ternary $poolCfg.daemonMemoryFloorMb $daemonCfg.daemonMemoryFloorMb (hasKey $poolCfg "daemonMemoryFloorMb") | quote }}
             - name: DAEMON_DISK_FLOOR_MB
-              value: {{ $poolCfg.daemonDiskFloorMb | default $daemonCfg.daemonDiskFloorMb | quote }}
+              value: {{ ternary $poolCfg.daemonDiskFloorMb $daemonCfg.daemonDiskFloorMb (hasKey $poolCfg "daemonDiskFloorMb") | quote }}
             {{- if $dindEnabled }}
             - name: DOCKER_HOST
               {{- if $rootless }}

--- a/charts/github-app-playground/templates/daemon-deployment.yaml
+++ b/charts/github-app-playground/templates/daemon-deployment.yaml
@@ -1,0 +1,266 @@
+{{- range $poolName, $pool := $.Values.daemon.pools }}
+{{- if ne ($pool.enabled | toString) "false" }}
+{{- $poolCfg := $pool.config | default dict }}
+{{- $daemonCfg := $.Values.daemon.config }}
+{{- $drainMs := int ($poolCfg.daemonDrainTimeoutMs | default $daemonCfg.daemonDrainTimeoutMs) }}
+{{- $gracePeriod := "" }}
+{{- if $pool.terminationGracePeriodSeconds }}
+{{- $gracePeriod = $pool.terminationGracePeriodSeconds }}
+{{- else if $.Values.daemon.terminationGracePeriodSeconds }}
+{{- $gracePeriod = $.Values.daemon.terminationGracePeriodSeconds }}
+{{- else }}
+{{- $gracePeriod = add (div $drainMs 1000) 30 }}
+{{- end }}
+{{- $dindDefaults := $.Values.daemon.dind | default dict }}
+{{- $poolDind := $pool.dind | default dict }}
+{{- $dindEnabled := $poolDind.enabled | default $dindDefaults.enabled | default false }}
+{{- $rootless := $poolDind.rootless | default $dindDefaults.rootless | default true }}
+{{- $dindStorageDefaults := $dindDefaults.storage | default dict }}
+{{- $dindStoragePool := $poolDind.storage | default dict }}
+{{- $dindStorageType := $dindStoragePool.type | default $dindStorageDefaults.type | default "emptyDir" }}
+{{- $dindSizeLimit := $dindStoragePool.sizeLimit | default $dindStorageDefaults.sizeLimit | default "10Gi" }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "github-app-playground.daemon.fullname" (dict "root" $ "poolName" $poolName) }}
+  labels:
+    {{- include "github-app-playground.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: daemon
+    app.kubernetes.io/pool: {{ $poolName }}
+spec:
+  {{- $autoscaling := $pool.autoscaling | default dict }}
+  {{- if not $autoscaling.enabled }}
+  replicas: {{ $pool.replicaCount | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "github-app-playground.daemon.selectorLabels" (dict "root" $ "poolName" $poolName) | nindent 6 }}
+  template:
+    metadata:
+      {{- with $pool.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "github-app-playground.labels" $ | nindent 8 }}
+        app.kubernetes.io/component: daemon
+        app.kubernetes.io/pool: {{ $poolName }}
+        {{- with $pool.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "github-app-playground.daemon.serviceAccountName" (dict "root" $ "pool" $pool) }}
+      {{- with ($pool.podSecurityContext | default dict) }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      # terminationGracePeriodSeconds must be >= daemonDrainTimeoutMs/1000 to allow
+      # in-flight jobs to complete before the pod is killed.
+      terminationGracePeriodSeconds: {{ $gracePeriod }}
+      containers:
+        - name: daemon
+          {{- with ($pool.securityContext | default dict) }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- $poolImg := $pool.image | default dict }}
+          {{- $rootImg := $.Values.image }}
+          image: "{{ $poolImg.repository | default $rootImg.repository }}:{{ $poolImg.tag | default $rootImg.tag | default $.Chart.AppVersion }}"
+          imagePullPolicy: {{ $poolImg.pullPolicy | default $rootImg.pullPolicy }}
+          command: ["bun", "run", "dist/daemon/main.js"]
+          envFrom:
+            - secretRef:
+                name: {{ include "github-app-playground.secretName" $ }}
+          env:
+            - name: ORCHESTRATOR_URL
+              value: {{ include "github-app-playground.daemon.orchestratorUrl" (dict "root" $ "pool" $pool) | quote }}
+            # Shared config keys sourced from the orchestrator ConfigMap
+            - name: CLAUDE_PROVIDER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "github-app-playground.fullname" $ }}-config
+                  key: CLAUDE_PROVIDER
+            - name: CLAUDE_MODEL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "github-app-playground.fullname" $ }}-config
+                  key: CLAUDE_MODEL
+                  optional: true
+            - name: LOG_LEVEL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "github-app-playground.fullname" $ }}-config
+                  key: LOG_LEVEL
+            - name: NODE_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "github-app-playground.fullname" $ }}-config
+                  key: NODE_ENV
+            - name: CLONE_BASE_DIR
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "github-app-playground.fullname" $ }}-config
+                  key: CLONE_BASE_DIR
+            - name: AGENT_TIMEOUT_MS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "github-app-playground.fullname" $ }}-config
+                  key: AGENT_TIMEOUT_MS
+            # Daemon-only knobs: pool override → cross-pool daemon.config default
+            - name: HEARTBEAT_INTERVAL_MS
+              value: {{ $poolCfg.heartbeatIntervalMs | default $daemonCfg.heartbeatIntervalMs | quote }}
+            - name: HEARTBEAT_TIMEOUT_MS
+              value: {{ $poolCfg.heartbeatTimeoutMs | default $daemonCfg.heartbeatTimeoutMs | quote }}
+            - name: STALE_EXECUTION_THRESHOLD_MS
+              value: {{ $poolCfg.staleExecutionThresholdMs | default $daemonCfg.staleExecutionThresholdMs | quote }}
+            - name: DAEMON_DRAIN_TIMEOUT_MS
+              value: {{ $drainMs | quote }}
+            - name: JOB_MAX_RETRIES
+              value: {{ $poolCfg.jobMaxRetries | default $daemonCfg.jobMaxRetries | quote }}
+            - name: OFFER_TIMEOUT_MS
+              value: {{ $poolCfg.offerTimeoutMs | default $daemonCfg.offerTimeoutMs | quote }}
+            - name: DAEMON_UPDATE_STRATEGY
+              value: {{ $poolCfg.daemonUpdateStrategy | default $daemonCfg.daemonUpdateStrategy | quote }}
+            - name: DAEMON_UPDATE_DELAY_MS
+              value: {{ $poolCfg.daemonUpdateDelayMs | default $daemonCfg.daemonUpdateDelayMs | quote }}
+            - name: DAEMON_EPHEMERAL
+              value: {{ $poolCfg.daemonEphemeral | default $daemonCfg.daemonEphemeral | quote }}
+            - name: DAEMON_MEMORY_FLOOR_MB
+              value: {{ $poolCfg.daemonMemoryFloorMb | default $daemonCfg.daemonMemoryFloorMb | quote }}
+            - name: DAEMON_DISK_FLOOR_MB
+              value: {{ $poolCfg.daemonDiskFloorMb | default $daemonCfg.daemonDiskFloorMb | quote }}
+            {{- if $dindEnabled }}
+            - name: DOCKER_HOST
+              {{- if $rootless }}
+              value: "unix:///run/user/1000/docker.sock"
+              {{- else }}
+              value: "unix:///var/run/docker.sock"
+              {{- end }}
+            {{- end }}
+            {{- with $pool.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - name: workspace
+              mountPath: {{ $.Values.config.cloneBaseDir | quote }}
+            {{- if $dindEnabled }}
+            - name: dind-socket
+              {{- if $rootless }}
+              mountPath: /run/user/1000
+              {{- else }}
+              mountPath: /var/run
+              {{- end }}
+            {{- end }}
+            {{- with $pool.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- $poolLiveness := $pool.livenessProbe | default dict }}
+          {{- if $poolLiveness.enabled }}
+          livenessProbe:
+            exec:
+              command: ["pgrep", "-f", "dist/daemon/main.js"]
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- end }}
+          {{- with ($pool.resources | default dict) }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- if $dindEnabled }}
+        - name: dind
+          {{- $dindImgDefaults := $dindDefaults.image | default dict }}
+          {{- $dindImgPool := $poolDind.image | default dict }}
+          {{- $dindRepo := $dindImgPool.repository | default $dindImgDefaults.repository | default "docker" }}
+          {{- $dindTagDefault := ternary "29-dind-rootless" "29-dind" $rootless }}
+          {{- $dindTag := $dindImgPool.tag | default $dindImgDefaults.tag | default $dindTagDefault }}
+          {{- $dindPullPolicy := $dindImgPool.pullPolicy | default $dindImgDefaults.pullPolicy | default "IfNotPresent" }}
+          image: "{{ $dindRepo }}:{{ $dindTag }}"
+          imagePullPolicy: {{ $dindPullPolicy }}
+          {{- if not $rootless }}
+          securityContext:
+            privileged: true
+          {{- end }}
+          {{- $dindResDefaults := $dindDefaults.resources | default dict }}
+          {{- $dindResPool := $poolDind.resources | default dict }}
+          {{- $dindRes := mergeOverwrite (deepCopy $dindResDefaults) $dindResPool }}
+          {{- with $dindRes }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: dind-socket
+              {{- if $rootless }}
+              mountPath: /run/user/1000
+            - name: dind-graph
+              mountPath: /home/rootless/.local/share/docker
+              {{- else }}
+              mountPath: /var/run
+            - name: dind-graph
+              mountPath: /var/lib/docker
+              {{- end }}
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                {{- if $rootless }}
+                - "test -S /run/user/1000/docker.sock"
+                {{- else }}
+                - "test -S /var/run/docker.sock"
+                {{- end }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 10
+          {{- $dindExtraEnv := concat ($dindDefaults.extraEnv | default list) ($poolDind.extraEnv | default list) }}
+          {{- with $dindExtraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- $dindExtraArgs := concat ($dindDefaults.extraArgs | default list) ($poolDind.extraArgs | default list) }}
+          {{- with $dindExtraArgs }}
+          args:
+            {{- range . }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      volumes:
+        - name: workspace
+          emptyDir: {}
+        {{- if $dindEnabled }}
+        - name: dind-socket
+          emptyDir: {}
+        - name: dind-graph
+          {{- if eq $dindStorageType "pvc" }}
+          persistentVolumeClaim:
+            claimName: {{ include "github-app-playground.daemon.fullname" (dict "root" $ "poolName" $poolName) }}-dind
+          {{- else }}
+          emptyDir:
+            sizeLimit: {{ $dindSizeLimit }}
+          {{- end }}
+        {{- end }}
+        {{- with $pool.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with $pool.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $pool.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $pool.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/github-app-playground/templates/daemon-deployment.yaml
+++ b/charts/github-app-playground/templates/daemon-deployment.yaml
@@ -1,5 +1,9 @@
+{{- $daemonPoolModes := list "daemon" "shared-runner" "auto" }}
 {{- range $poolName, $pool := $.Values.daemon.pools }}
 {{- if ne ($pool.enabled | toString) "false" }}
+{{- if not (has $.Values.config.agentJobMode $daemonPoolModes) }}
+{{- fail (printf "daemon.pools.%s requires config.agentJobMode to be daemon, shared-runner, or auto (got: %s)" $poolName $.Values.config.agentJobMode) }}
+{{- end }}
 {{- $poolCfg := $pool.config | default dict }}
 {{- $daemonCfg := $.Values.daemon.config }}
 {{- $drainMs := int (ternary $poolCfg.daemonDrainTimeoutMs $daemonCfg.daemonDrainTimeoutMs (hasKey $poolCfg "daemonDrainTimeoutMs")) }}
@@ -37,7 +41,7 @@ metadata:
 spec:
   {{- $autoscaling := $pool.autoscaling | default dict }}
   {{- if not $autoscaling.enabled }}
-  replicas: {{ $pool.replicaCount | default 1 }}
+  replicas: {{ ternary $pool.replicaCount 1 (hasKey $pool "replicaCount") }}
   {{- end }}
   selector:
     matchLabels:
@@ -198,10 +202,8 @@ spec:
           {{- $dindPullPolicy := $dindImgPool.pullPolicy | default $dindImgDefaults.pullPolicy | default "IfNotPresent" }}
           image: "{{ $dindRepo }}:{{ $dindTag }}"
           imagePullPolicy: {{ $dindPullPolicy }}
-          {{- if not $rootless }}
           securityContext:
             privileged: true
-          {{- end }}
           {{- $dindResDefaults := $dindDefaults.resources | default dict }}
           {{- $dindResPool := $poolDind.resources | default dict }}
           {{- $dindRes := mergeOverwrite (deepCopy $dindResDefaults) $dindResPool }}

--- a/charts/github-app-playground/templates/daemon-hpa.yaml
+++ b/charts/github-app-playground/templates/daemon-hpa.yaml
@@ -1,0 +1,40 @@
+{{- range $poolName, $pool := $.Values.daemon.pools }}
+{{- if ne ($pool.enabled | toString) "false" }}
+{{- $autoscaling := $pool.autoscaling | default dict }}
+{{- if $autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "github-app-playground.daemon.fullname" (dict "root" $ "poolName" $poolName) }}
+  labels:
+    {{- include "github-app-playground.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: daemon
+    app.kubernetes.io/pool: {{ $poolName }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "github-app-playground.daemon.fullname" (dict "root" $ "poolName" $poolName) }}
+  minReplicas: {{ $autoscaling.minReplicas | default 1 }}
+  maxReplicas: {{ $autoscaling.maxReplicas | default 5 }}
+  metrics:
+    {{- if $autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/github-app-playground/templates/daemon-pdb.yaml
+++ b/charts/github-app-playground/templates/daemon-pdb.yaml
@@ -12,10 +12,12 @@ metadata:
     app.kubernetes.io/component: daemon
     app.kubernetes.io/pool: {{ $poolName }}
 spec:
-  {{- if $pdb.maxUnavailable }}
+  {{- if hasKey $pdb "maxUnavailable" }}
   maxUnavailable: {{ $pdb.maxUnavailable }}
+  {{- else if hasKey $pdb "minAvailable" }}
+  minAvailable: {{ $pdb.minAvailable }}
   {{- else }}
-  minAvailable: {{ $pdb.minAvailable | default 1 }}
+  minAvailable: 1
   {{- end }}
   selector:
     matchLabels:

--- a/charts/github-app-playground/templates/daemon-pdb.yaml
+++ b/charts/github-app-playground/templates/daemon-pdb.yaml
@@ -1,0 +1,25 @@
+{{- range $poolName, $pool := $.Values.daemon.pools }}
+{{- if ne ($pool.enabled | toString) "false" }}
+{{- $pdb := $pool.podDisruptionBudget | default dict }}
+{{- if $pdb.enabled }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "github-app-playground.daemon.fullname" (dict "root" $ "poolName" $poolName) }}
+  labels:
+    {{- include "github-app-playground.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: daemon
+    app.kubernetes.io/pool: {{ $poolName }}
+spec:
+  {{- if $pdb.maxUnavailable }}
+  maxUnavailable: {{ $pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ $pdb.minAvailable | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "github-app-playground.daemon.selectorLabels" (dict "root" $ "poolName" $poolName) | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/github-app-playground/templates/deployment.yaml
+++ b/charts/github-app-playground/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
             - name: http
               containerPort: {{ .Values.config.port }}
               protocol: TCP
+            - name: ws
+              containerPort: {{ .Values.config.wsPort }}
+              protocol: TCP
           envFrom:
             - configMapRef:
                 name: {{ include "github-app-playground.fullname" . }}-config

--- a/charts/github-app-playground/templates/deployment.yaml
+++ b/charts/github-app-playground/templates/deployment.yaml
@@ -19,6 +19,7 @@ spec:
       {{- end }}
       labels:
         {{- include "github-app-playground.labels" . | nindent 8 }}
+        app.kubernetes.io/component: orchestrator
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/github-app-playground/templates/service.yaml
+++ b/charts/github-app-playground/templates/service.yaml
@@ -20,4 +20,3 @@ spec:
     {{- end }}
   selector:
     {{- include "github-app-playground.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: orchestrator

--- a/charts/github-app-playground/templates/service.yaml
+++ b/charts/github-app-playground/templates/service.yaml
@@ -12,5 +12,11 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if or (ne .Values.config.agentJobMode "inline") .Values.daemon.pools }}
+    - port: {{ .Values.config.wsPort }}
+      targetPort: ws
+      protocol: TCP
+      name: ws
+    {{- end }}
   selector:
     {{- include "github-app-playground.selectorLabels" . | nindent 4 }}

--- a/charts/github-app-playground/templates/service.yaml
+++ b/charts/github-app-playground/templates/service.yaml
@@ -20,3 +20,4 @@ spec:
     {{- end }}
   selector:
     {{- include "github-app-playground.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: orchestrator

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -353,8 +353,8 @@ config:
   orchestratorUrl: ""                           # Setting this flips the process to DAEMON mode (webhook HTTP not started).
   heartbeatIntervalMs: 30000
   heartbeatTimeoutMs: 90000                     # Keep >= 2 x heartbeatIntervalMs.
-  staleExecutionThresholdMs: 600000             # Must exceed agentTimeoutMs.
-  daemonDrainTimeoutMs: 300000                  # Set >= agentTimeoutMs to avoid mid-run kills on SIGTERM.
+  staleExecutionThresholdMs: 660000             # Must exceed agentTimeoutMs (600000).
+  daemonDrainTimeoutMs: 600000                  # Set >= agentTimeoutMs to avoid mid-run kills on SIGTERM.
   jobMaxRetries: 3                              # Daemon-dispatch retry only. isolated-job ignores this (FR-021).
   offerTimeoutMs: 5000
   daemonUpdateStrategy: exit                    # exit | pull | notify.
@@ -404,8 +404,8 @@ daemon:
   config:
     heartbeatIntervalMs: 30000         # HEARTBEAT_INTERVAL_MS
     heartbeatTimeoutMs: 90000          # HEARTBEAT_TIMEOUT_MS (keep >= 2× interval)
-    staleExecutionThresholdMs: 600000  # STALE_EXECUTION_THRESHOLD_MS
-    daemonDrainTimeoutMs: 300000       # DAEMON_DRAIN_TIMEOUT_MS
+    staleExecutionThresholdMs: 660000  # STALE_EXECUTION_THRESHOLD_MS; must exceed agentTimeoutMs (600000)
+    daemonDrainTimeoutMs: 600000       # DAEMON_DRAIN_TIMEOUT_MS; must be >= agentTimeoutMs to avoid mid-run kills
     jobMaxRetries: 3                   # JOB_MAX_RETRIES
     offerTimeoutMs: 5000               # OFFER_TIMEOUT_MS
     daemonUpdateStrategy: exit         # exit | pull | notify

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -379,3 +379,106 @@ config:
   # --- 14. Isolated-job capacity back-pressure (FR-018, US3) ---
   maxConcurrentIsolatedJobs: 3
   pendingIsolatedJobQueueMax: 20
+
+# ─────────────────────────── DAEMON POOLS ─────────────────────────────
+# `daemon:` configures 0..N stateless daemon worker pools. Each pool
+# renders its own Deployment. Daemons connect outbound to the orchestrator
+# WebSocket on :config.wsPort and register via a shared DAEMON_AUTH_TOKEN.
+#
+# The orchestrator's Service gains a `ws` port when any pool is defined
+# (or when config.agentJobMode is non-inline), so daemons can reach it at
+# ws://<fullname>:<config.wsPort>/ws.
+#
+# All pools share the same Docker image (default CMD overridden to daemon
+# entry point) and the same app Secret (for DAEMON_AUTH_TOKEN and AI keys).
+# Pool-level config keys override cross-pool `daemon.config` defaults.
+daemon:
+  orchestratorUrl: ""                  # empty → auto-computed ws://<fullname>:<wsPort>/ws
+  terminationGracePeriodSeconds: ""    # empty → daemonDrainTimeoutMs/1000 + 30
+
+  serviceAccount:
+    name: ""                           # empty → inherits orchestrator SA
+
+  # Daemon-runtime defaults sourced from github-app-playground/.env.example.
+  # Each pool can override any key under its own `config:` block.
+  config:
+    heartbeatIntervalMs: 30000         # HEARTBEAT_INTERVAL_MS
+    heartbeatTimeoutMs: 90000          # HEARTBEAT_TIMEOUT_MS (keep >= 2× interval)
+    staleExecutionThresholdMs: 600000  # STALE_EXECUTION_THRESHOLD_MS
+    daemonDrainTimeoutMs: 300000       # DAEMON_DRAIN_TIMEOUT_MS
+    jobMaxRetries: 3                   # JOB_MAX_RETRIES
+    offerTimeoutMs: 5000               # OFFER_TIMEOUT_MS
+    daemonUpdateStrategy: exit         # exit | pull | notify
+    daemonUpdateDelayMs: 0             # DAEMON_UPDATE_DELAY_MS
+    daemonEphemeral: false             # DAEMON_EPHEMERAL
+    daemonMemoryFloorMb: 512           # DAEMON_MEMORY_FLOOR_MB
+    daemonDiskFloorMb: 1024            # DAEMON_DISK_FLOOR_MB
+
+  # DinD sidecar defaults. Pools that set dind.enabled=true inherit any
+  # omitted field from here. Rootless DinD is default and works under PSS
+  # baseline. Classic DinD (rootless: false) requires privileged: true
+  # and a permissive namespace PSA label.
+  dind:
+    enabled: false
+    image:
+      repository: docker
+      tag: "29-dind-rootless"          # switch to "29-dind" for classic
+      pullPolicy: IfNotPresent
+    rootless: true                     # false → privileged sidecar
+    resources:
+      requests:
+        cpu: 250m
+        memory: 512Mi
+      limits:
+        cpu: 2000m
+        memory: 4Gi
+    storage:
+      type: emptyDir                   # emptyDir | pvc
+      sizeLimit: 10Gi                  # emptyDir sizeLimit only
+      size: ""                         # pvc size (only when type: pvc)
+      storageClass: ""
+    extraEnv: []
+    extraArgs: []                      # extra dockerd flags
+
+  # Named pools. Each entry renders one Deployment.
+  # Set enabled: false on a pool to stage it without rolling out.
+  #
+  # pools:
+  #   default:
+  #     replicaCount: 2
+  #     resources:
+  #       requests: { cpu: 250m, memory: 256Mi }
+  #       limits:   { cpu: 1000m, memory: 1Gi }
+  #     nodeSelector: {}
+  #     tolerations: []
+  #     affinity: {}
+  #     podSecurityContext: {}
+  #     securityContext: {}
+  #     podAnnotations: {}
+  #     podLabels: {}
+  #     extraEnv: []
+  #     volumes: []
+  #     volumeMounts: []
+  #     livenessProbe:
+  #       enabled: false               # opt-in pgrep-based exec probe
+  #     autoscaling:
+  #       enabled: false
+  #       minReplicas: 1
+  #       maxReplicas: 5
+  #       targetCPUUtilizationPercentage: 80
+  #     podDisruptionBudget:
+  #       enabled: false
+  #       minAvailable: 1
+  #     config: {}                     # overrides any key from daemon.config above
+  #     dind:
+  #       enabled: false               # set true to add a DinD sidecar
+  #   docker-heavy:
+  #     replicaCount: 1
+  #     resources:
+  #       requests: { cpu: 1000m, memory: 2Gi }
+  #       limits:   { cpu: 4000m, memory: 8Gi }
+  #     dind:
+  #       enabled: true
+  #       rootless: false              # privileged; requires permissive PSA namespace label
+  #       storage: { type: pvc, size: 50Gi }
+  pools: {}

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -422,9 +422,9 @@ daemon:
     enabled: false
     image:
       repository: docker
-      tag: "29-dind-rootless"          # switch to "29-dind" for classic
+      tag: ""                          # empty → auto-selected: 29-dind-rootless (rootless=true) or 29-dind (rootless=false)
       pullPolicy: IfNotPresent
-    rootless: true                     # false → privileged sidecar
+    rootless: true                     # false → privileged sidecar; auto-selects docker:29-dind image
     resources:
       requests:
         cpu: 250m


### PR DESCRIPTION
## Summary

Adds named daemon pool support to the `github-app-playground` Helm chart (v0.4.0). The upstream app already ships a daemon worker mode (`bun run dist/daemon/main.js`) that connects outbound to the orchestrator's WebSocket server and executes agent jobs. This PR makes it possible to deploy one or more daemon pools alongside the orchestrator within the same Helm release.

The change is **non-breaking**: `daemon.pools` defaults to `{}`, so existing installs render zero daemon Deployments and are unaffected.

### Before — orchestrator only

```mermaid
flowchart LR
  classDef svc fill:#1565C0,color:#FFFFFF,stroke:#0D47A1
  classDef pod fill:#2E7D32,color:#FFFFFF,stroke:#1B5E20
  classDef ext fill:#4E342E,color:#FFFFFF,stroke:#3E2723

  GH["GitHub Webhook"]:::ext
  SVC["Service<br/>:80 http"]:::svc
  ORC["Deployment<br/>orchestrator"]:::pod
  GH --> SVC --> ORC
```

### After — orchestrator + named daemon pools

```mermaid
flowchart LR
  classDef svc fill:#1565C0,color:#FFFFFF,stroke:#0D47A1
  classDef pod fill:#2E7D32,color:#FFFFFF,stroke:#1B5E20
  classDef ext fill:#4E342E,color:#FFFFFF,stroke:#3E2723
  classDef dind fill:#6A1B9A,color:#FFFFFF,stroke:#4A148C

  GH["GitHub Webhook"]:::ext
  SVC["Service<br/>:80 http<br/>:3002 ws"]:::svc
  ORC["Deployment<br/>orchestrator"]:::pod
  GH --> SVC --> ORC
  SVC --ws--> DMN1["Deployment<br/>daemon-default<br/>replicaCount: N"]:::pod
  SVC --ws--> DMN2["Deployment<br/>daemon-docker-heavy<br/>replicaCount: N"]:::pod
  DMN2 --- DIND["Sidecar<br/>docker:29-dind-rootless"]:::dind
```

## Changes

### New templates
- `templates/daemon-deployment.yaml` — ranges over `daemon.pools`; renders one Deployment per named pool with:
  - Command override to `bun run dist/daemon/main.js`
  - `envFrom: secretRef` for `DAEMON_AUTH_TOKEN` and AI keys (shared secret)
  - `ORCHESTRATOR_URL` auto-computed as `ws://<fullname>:<wsPort>/ws` unless overridden
  - Shared config keys sourced via `configMapKeyRef` (avoids duplicating ConfigMap)
  - Full daemon knob set (`HEARTBEAT_INTERVAL_MS`, `DAEMON_DRAIN_TIMEOUT_MS`, etc.) with cross-pool defaults from upstream `.env.example`
  - Optional Docker-in-Docker sidecar (`dind.enabled: true`) with rootless default and socket sharing via `emptyDir`
  - `terminationGracePeriodSeconds` auto-derived as `daemonDrainTimeoutMs/1000 + 30`
- `templates/daemon-hpa.yaml` — one HPA per pool where `autoscaling.enabled: true`
- `templates/daemon-pdb.yaml` — one PDB per pool where `podDisruptionBudget.enabled: true`
- `ci/daemon-pools-values.yaml` — CI fixture: `agentJobMode: daemon`, in-chart Postgres+Valkey, two pools (`default` no-DinD, `docker-heavy` rootless DinD)

### Modified files
- `Chart.yaml` — version bump `0.3.0` → `0.4.0`
- `templates/deployment.yaml` — adds `ws` named containerPort (`:config.wsPort`, default 3002) so the Service can target it by name
- `templates/service.yaml` — conditionally adds `ws` service port when `agentJobMode != inline` OR any pool is defined
- `templates/_helpers.tpl` — four new daemon helpers: `daemon.fullname`, `daemon.selectorLabels`, `daemon.serviceAccountName`, `daemon.orchestratorUrl`
- `values.yaml` — new top-level `daemon:` block with `pools: {}` default, cross-pool `config` defaults (sourced from `.env.example`), and `dind` sidecar defaults
- `templates/NOTES.txt` — daemon pools usage section + `0.3.x → 0.4.0` upgrade notes (non-breaking)
- `.github/workflows/lint.yml` — adds scenario 6 to feature matrix: two-pool daemon render with CI values file

### Key design decisions
- **`ORCHESTRATOR_URL` not in ConfigMap** — placing it there would flip the orchestrator itself into daemon mode per `src/config.ts` Zod validation; it is set exclusively as an explicit env var on daemon pods
- **`ne ($pool.enabled | toString) "false"`** — correct idiom for "render unless explicitly disabled"; `$pool.enabled | default true` would fail because Helm's `default` treats `false` as falsy
- **Rootless DinD by default** — `docker:29-dind-rootless` works under PSS `baseline` without `privileged: true`; classic DinD is opt-in via `dind.rootless: false`
- **Same image, different entry point** — the upstream app ships one image; daemon mode is activated by overriding the container command, matching the upstream `scripts/run-daemon.sh` pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced daemon pool support enabling multiple stateless worker pool configurations.
  * Added Docker-in-Docker sidecar support with rootless mode option.
  * Added horizontal pod autoscaling and pod disruption budgets for daemon pools.
  * Added WebSocket connectivity port for daemon integration.

* **Documentation**
  * Updated release notes with daemon pool deployment guidance and prerequisites.

* **Chores**
  * Bumped chart version to 0.4.0.
  * Extended CI workflow validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->