### PR TITLE
fix(github-app-playground): project ALLOWED_OWNERS into daemon env + bump appVersion to 1.1.1 (v0.4.2)

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.0"
+appVersion: "1.1.1"
 
 kubeVersion: ">= 1.31.0"
 

--- a/charts/github-app-playground/templates/daemon-deployment.yaml
+++ b/charts/github-app-playground/templates/daemon-deployment.yaml
@@ -130,6 +130,16 @@ spec:
                   name: {{ include "github-app-playground.fullname" $ }}-config
                   key: AGENT_TIMEOUT_MS
                   optional: true
+            # Required by the daemon's config validator when CLAUDE_CODE_OAUTH_TOKEN
+            # is set; startup fails with "ALLOWED_OWNERS must contain exactly one
+            # owner..." if unset. Optional here because anthropic-API-key and
+            # bedrock deployments don't need it.
+            - name: ALLOWED_OWNERS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "github-app-playground.fullname" $ }}-config
+                  key: ALLOWED_OWNERS
+                  optional: true
             # Daemon-only knobs: pool override → cross-pool daemon.config default
             - name: HEARTBEAT_INTERVAL_MS
               value: {{ ternary $poolCfg.heartbeatIntervalMs $daemonCfg.heartbeatIntervalMs (hasKey $poolCfg "heartbeatIntervalMs") | quote }}


### PR DESCRIPTION
## Summary

Two chart changes bundled together, both tracking the upstream `github-app-playground` runtime.

### 1. Project `ALLOWED_OWNERS` into daemon env (chart 0.4.1)

- Daemon Deployment template (chart 0.4.0) projected only 6 keys from the ConfigMap (`CLAUDE_PROVIDER`, `CLAUDE_MODEL`, `LOG_LEVEL`, `NODE_ENV`, `CLONE_BASE_DIR`, `AGENT_TIMEOUT_MS`) but omitted `ALLOWED_OWNERS`. When `CLAUDE_CODE_OAUTH_TOKEN` is set, the daemon's startup validator rejects the pod with: `ALLOWED_OWNERS must contain exactly one owner when CLAUDE_CODE_OAUTH_TOKEN is set`.
- The orchestrator Deployment gets this key via `envFrom` (ConfigMap reference), so only the daemon template needed fixing.
- `configMapKeyRef.optional: true` keeps anthropic-API-key and Bedrock deployments (which don't set `config.allowedOwners`) working unchanged — the env var is simply absent, matching previous behavior.

### 2. Bump `appVersion` to 1.1.1 (chart 0.4.2)

- Track upstream [`github-app-playground` v1.1.1](https://github.com/chrisleekr/github-app-playground/releases/tag/v1.1.1), which ships the `NODE_ENV=production` build-time fix and the bundled daemon entrypoint (upstream PR #31).
- Chart-only metadata change; values schema unchanged.

## Context

Discovered while deploying `chrisleekr/github-app-playground@1.1.1-dev` via ArgoCD — daemon pod CrashLoopBackOff. Root cause is the validator in `github-app-playground` at `src/config.ts` which enforces single-tenant safety when OAuth-token auth is used.

Downstream workaround currently in my `argocd-apps` values:

```yaml
daemon:
  pools:
    default:
      extraEnv:
        - name: ALLOWED_OWNERS
          valueFrom:
            configMapKeyRef:
              name: github-app-playground-config
              key: ALLOWED_OWNERS
              optional: false
```

Once this PR lands and the chart is republished, that override can be removed.

## Test plan

- [x] `helm template test ./charts/github-app-playground -f ./charts/github-app-playground/ci/daemon-pools-values.yaml` renders `ALLOWED_OWNERS` in both daemon pool Deployments (default and docker-heavy).
- [x] `helm template test ./charts/github-app-playground -f ... --set config.allowedOwners=chrisleekr` renders `ALLOWED_OWNERS: "chrisleekr"` in the ConfigMap so the new env ref resolves.
- [x] `helm lint ./charts/github-app-playground` passes on 0.4.2.
- [ ] After merge + chart release: redeploy downstream argocd-apps with `extraEnv` block removed and confirm daemon pod comes up cleanly on `appVersion 1.1.1`.

Generated with [Claude Code](https://claude.com/claude-code)
