### PR TITLE
fix(github-app-playground): grant daemon supplementalGroups for docker.sock when dind.rootless=false (v0.4.3)

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/github-app-playground/templates/daemon-deployment.yaml
+++ b/charts/github-app-playground/templates/daemon-deployment.yaml
@@ -72,10 +72,16 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "github-app-playground.daemon.serviceAccountName" (dict "root" $ "pool" $pool) }}
+      {{- /* Coerce every supplementalGroup entry to int so mixed string/int
+             operator input does not defeat uniq and still renders as a
+             homogeneous int64 list the Kubernetes API accepts. */}}
       {{- $podSecCtx := deepCopy ($pool.podSecurityContext | default dict) }}
       {{- if and $dindEnabled (not $rootless) }}
-      {{-   $existingGroups := $podSecCtx.supplementalGroups | default list }}
-      {{-   $_ := set $podSecCtx "supplementalGroups" (append $existingGroups $socketGid | uniq) }}
+      {{-   $existingGroups := list }}
+      {{-   range ($podSecCtx.supplementalGroups | default list) }}
+      {{-     $existingGroups = append $existingGroups (int .) }}
+      {{-   end }}
+      {{-   $_ := set $podSecCtx "supplementalGroups" (append $existingGroups (int $socketGid) | uniq) }}
       {{- end }}
       {{- with $podSecCtx }}
       securityContext:

--- a/charts/github-app-playground/templates/daemon-deployment.yaml
+++ b/charts/github-app-playground/templates/daemon-deployment.yaml
@@ -25,6 +25,13 @@
 {{- if hasKey $poolDind "rootless" }}{{- $rootless = $poolDind.rootless }}
 {{- else if hasKey $dindDefaults "rootless" }}{{- $rootless = $dindDefaults.rootless }}
 {{- end }}
+{{- /* When rootless=false, dockerd runs as root and creates /var/run/docker.sock
+       as root:docker(gid=2375). The daemon (uid 1000) must be a member of that
+       group to open the socket. socketGid is only consulted in that path. */}}
+{{- $socketGid := 2375 }}
+{{- if hasKey $poolDind "socketGid" }}{{- $socketGid = $poolDind.socketGid }}
+{{- else if hasKey $dindDefaults "socketGid" }}{{- $socketGid = $dindDefaults.socketGid }}
+{{- end }}
 {{- $dindStorageDefaults := $dindDefaults.storage | default dict }}
 {{- $dindStoragePool := $poolDind.storage | default dict }}
 {{- $dindStorageType := $dindStoragePool.type | default $dindStorageDefaults.type | default "emptyDir" }}
@@ -65,7 +72,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "github-app-playground.daemon.serviceAccountName" (dict "root" $ "pool" $pool) }}
-      {{- with ($pool.podSecurityContext | default dict) }}
+      {{- $podSecCtx := deepCopy ($pool.podSecurityContext | default dict) }}
+      {{- if and $dindEnabled (not $rootless) }}
+      {{-   $existingGroups := $podSecCtx.supplementalGroups | default list }}
+      {{-   $_ := set $podSecCtx "supplementalGroups" (append $existingGroups $socketGid | uniq) }}
+      {{- end }}
+      {{- with $podSecCtx }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -425,6 +425,12 @@ daemon:
       tag: ""                          # empty → auto-selected: 29-dind-rootless (rootless=true) or 29-dind (rootless=false)
       pullPolicy: IfNotPresent
     rootless: true                     # false → privileged sidecar; auto-selects docker:29-dind image
+    # Only consulted when rootless=false. The dockerd process runs as root and
+    # creates /var/run/docker.sock owned by root:docker. socketGid must match the
+    # "docker" group gid inside the DinD image (2375 in docker:29-dind). When set,
+    # the chart adds it to pod supplementalGroups so the daemon container (uid
+    # 1000) can open the socket without running as root.
+    socketGid: 2375
     resources:
       requests:
         cpu: 250m

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -422,6 +422,10 @@ daemon:
     enabled: false
     image:
       repository: docker
+      # The DinD image determines the "docker" group gid baked into the image
+      # (2375 in docker:29-dind). If you bump this tag to a future major, verify
+      # that daemon.dind.socketGid below still matches or the non-rootless
+      # daemon will regress to "permission denied" on /var/run/docker.sock.
       tag: ""                          # empty → auto-selected: 29-dind-rootless (rootless=true) or 29-dind (rootless=false)
       pullPolicy: IfNotPresent
     rootless: true                     # false → privileged sidecar; auto-selects docker:29-dind image


### PR DESCRIPTION
## Summary

When `daemon.dind.rootless=false`, the privileged DinD sidecar runs dockerd as root and creates `/var/run/docker.sock` owned by `root:docker(gid=2375)` mode `0660`. The daemon container runs as `uid=1000(bun)` with only supplementary group 1000, so it gets `permission denied` when calling `docker`. With `rootless=true` the daemon and dockerd shared uid 1000 and it worked accidentally — the chart never bridged the gap for the non-rootless path.

This patch adds pod-level `supplementalGroups: [<socketGid>]` to the daemon pool pod whenever DinD is enabled and `rootless=false`, giving the `bun` user membership of the `docker` group and write access to the socket — without running the daemon as root.

The group id is exposed as `daemon.dind.socketGid` (default `2375`, matching `docker:29-dind`) so operators can track the upstream image if the gid ever changes.

Verified on cluster: before the fix, `kubectl exec` into the daemon container and `docker version` returns `permission denied while trying to connect to the docker API at unix:///var/run/docker.sock`. After the fix, the bun user has `groups=1000(bun),2375` and `docker version` returns successfully.

**Impact scope (narrow):** the static job classifier in the app (`src/webhook/router.ts`) already routes docker/compose/dind jobs to `isolated-job`, which has its own DinD. Only jobs that land on the daemon pool *and* internally shell out to `docker` were affected. Typical bot comments were unaffected, but `dind.rootless=false` is now a first-class supported path.

### Before

```mermaid
flowchart LR
  Daemon["daemon<br/>uid=1000 bun<br/>groups=1000"]:::fail
  Dind["dind<br/>privileged<br/>root 0:0"]:::dind
  Sock["/var/run/docker.sock<br/>root:docker 2375<br/>mode 0660"]:::sock
  Dind -->|creates| Sock
  Daemon -->|open| Sock
  Daemon -. permission denied .-> Sock
  classDef fail fill:#b00020,color:#ffffff,stroke:#400010
  classDef dind fill:#0b5394,color:#ffffff,stroke:#062a52
  classDef sock fill:#616161,color:#ffffff,stroke:#212121
```

### After

```mermaid
flowchart LR
  Pod["pod.securityContext.supplementalGroups: [2375]"]:::pod
  Daemon["daemon<br/>uid=1000 bun<br/>groups=1000,2375"]:::ok
  Dind["dind<br/>privileged<br/>root 0:0"]:::dind
  Sock["/var/run/docker.sock<br/>root:docker 2375<br/>mode 0660"]:::sock
  Pod --- Daemon
  Pod --- Dind
  Dind -->|creates| Sock
  Daemon -->|open OK| Sock
  classDef pod fill:#1b5e20,color:#ffffff,stroke:#0d2f10
  classDef ok fill:#2e7d32,color:#ffffff,stroke:#14401a
  classDef dind fill:#0b5394,color:#ffffff,stroke:#062a52
  classDef sock fill:#616161,color:#ffffff,stroke:#212121
```

## Changes

- **`charts/github-app-playground/templates/daemon-deployment.yaml`**
  - Resolve `$socketGid` alongside `$rootless` using the existing pool → daemon-default precedence (`hasKey` lookup, default `2375`).
  - Build the pod-level `securityContext` from a `deepCopy` of `$pool.podSecurityContext`; when `dindEnabled && !rootless`, append `$socketGid` to `supplementalGroups` via `append ... | uniq` so any operator-set list is preserved and not duplicated.
  - Container-level `securityContext` (`runAsUser/runAsGroup: 1000` for rootless=true) is untouched.
- **`charts/github-app-playground/values.yaml`**
  - Add `daemon.dind.socketGid: 2375` with a comment clarifying it is only consulted when `rootless=false` and should match the `docker` group gid inside the DinD image.
- **`charts/github-app-playground/Chart.yaml`**
  - Bump chart version `0.4.2` → `0.4.3` (patch: bug fix, no appVersion change).

## Verification

- `helm lint charts/github-app-playground` clean.
- `helm template` with three scenarios:
  - `rootless=true` → no `supplementalGroups` rendered, rootless DinD image used, container `runAsUser:1000` unchanged.
  - `rootless=false` → pod `supplementalGroups: [2375]`, non-rootless DinD image, privileged sidecar.
  - Pool override (`rootless:false`, `socketGid:1999`, pre-existing `podSecurityContext.supplementalGroups:[9999]` and `runAsNonRoot:true`) → renders `supplementalGroups: [9999, 1999]` and preserves `runAsNonRoot:true`; pool `socketGid` beats daemon default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable socket group ID setting for Docker daemon Docker-in-Docker mode, enabling improved socket access control.
* **Chores**
  * Bumped Helm chart version to 0.4.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->