### PR TITLE
feat(github-app-playground)!: collapse dispatch to daemon-only (v0.6.0)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,23 +31,19 @@ jobs:
         run: |
           chart=charts/github-app-playground
           set -euo pipefail
-          # 1. Phase 1 (inline) — current production topology.
+          # 1. Defaults — daemon-only dispatch, no ephemeral spawn knobs overridden.
           helm template "$chart" > /dev/null
           # 2. Bedrock provider path.
           helm template "$chart" \
             --set config.provider=bedrock \
             --set config.awsRegion=us-east-1 \
             --set config.model=us.anthropic.claude-sonnet-4-5-v1:0 > /dev/null
-          # 3. In-chart Postgres + Valkey + RBAC + external shared-runner URL
-          #    (sharedRunner Deployment was removed in chart 0.5.0; the
-          #    agentJobMode=shared-runner path now requires an operator-hosted
-          #    runner at config.internalRunnerUrl).
+          # 3. In-chart Postgres + Valkey + RBAC (rbac.create=true now provisions
+          #    a Role for ephemeral daemon Pod spawning — see upstream PR #35).
           helm template "$chart" \
             --set postgres.enabled=true --set valkey.enabled=true \
-            --set rbac.create=true \
-            --set config.agentJobMode=shared-runner \
-            --set config.internalRunnerUrl=http://runner.example.svc:7081 > /dev/null
-          # 4. Phase 4 with external Postgres + Valkey (literal password path).
+            --set rbac.create=true > /dev/null
+          # 4. External Postgres + Valkey (literal password path).
           helm template "$chart" \
             --set postgres.external.enabled=true \
             --set postgres.external.host=pg \
@@ -56,14 +52,17 @@ jobs:
             --set postgres.external.password=p \
             --set valkey.external.enabled=true \
             --set valkey.external.host=r \
-            --set valkey.external.auth.password=p \
-            --set config.internalRunnerUrl=http://runner.example.svc:7081 \
-            --set config.agentJobMode=auto > /dev/null
+            --set valkey.external.auth.password=p > /dev/null
           # 5. User-supplied URLs (neither in-chart nor external enabled).
           helm template "$chart" \
             --set config.databaseUrl=postgres://u:p@h/d \
-            --set config.valkeyUrl=redis://h:6379 \
-            --set config.agentJobMode=daemon > /dev/null
+            --set config.valkeyUrl=redis://h:6379 > /dev/null
           # 6. Daemon pools: default (no DinD) + docker-heavy (rootless DinD).
           helm template "$chart" \
             --values "$chart/ci/daemon-pools-values.yaml" > /dev/null
+          # 7. Ephemeral daemon scale-up: RBAC + public orchestrator URL + overrides.
+          helm template "$chart" \
+            --set rbac.create=true \
+            --set config.ephemeralDaemon.orchestratorPublicUrl=ws://orchestrator.example:3002/ws \
+            --set config.ephemeralDaemon.namespace=agents \
+            --set config.ephemeralDaemon.spawnQueueThreshold=5 > /dev/null

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,9 +60,14 @@ jobs:
           # 6. Daemon pools: default (no DinD) + docker-heavy (rootless DinD).
           helm template "$chart" \
             --values "$chart/ci/daemon-pools-values.yaml" > /dev/null
-          # 7. Ephemeral daemon scale-up: RBAC + public orchestrator URL + overrides.
+          # 7. Ephemeral daemon scale-up (chart-managed RBAC): namespace stays at
+          #    the release namespace so role.yaml's cross-namespace guard is happy.
           helm template "$chart" \
             --set rbac.create=true \
             --set config.ephemeralDaemon.orchestratorPublicUrl=ws://orchestrator.example:3002/ws \
-            --set config.ephemeralDaemon.namespace=agents \
             --set config.ephemeralDaemon.spawnQueueThreshold=5 > /dev/null
+          # 8. Ephemeral daemon scale-up (operator-managed RBAC): rbac.create=false
+          #    releases the namespace lock, so cross-namespace spawn is allowed.
+          helm template "$chart" \
+            --set rbac.create=false \
+            --set config.ephemeralDaemon.namespace=agents > /dev/null

--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.0"
+appVersion: "1.3.0"
 
 kubeVersion: ">= 1.31.0"
 
@@ -45,12 +45,16 @@ annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
     - kind: changed
-      description: "BREAKING: bump appVersion to 1.2.0 (upstream split orchestrator/daemon images)"
-    - kind: changed
-      description: "BREAKING: image.tag is removed; use image.orchestrator.tag and image.daemon.tag"
+      description: "BREAKING: bump appVersion to 1.3.0 (upstream PR #35 collapses dispatch surface to daemon-only)"
     - kind: removed
-      description: "BREAKING: sharedRunner Deployment/Service removed (dormant feature, superseded by daemon pools). Use an external runner with config.internalRunnerUrl for agentJobMode=shared-runner."
+      description: "BREAKING: config.agentJobMode and config.defaultDispatchTarget removed — dispatch is daemon-only"
+    - kind: removed
+      description: "BREAKING: config.internalRunnerUrl and secrets.internalRunnerToken/sharedRunnerToken removed (shared-runner target gone)"
+    - kind: removed
+      description: "BREAKING: config.jobNamespace/jobImage/jobTtlSeconds/jobActiveDeadlineSeconds/jobWatchPollIntervalMs/jobMaxCostUsd/maxConcurrentIsolatedJobs/pendingIsolatedJobQueueMax removed (isolated-job target gone)"
+    - kind: removed
+      description: "BREAKING: config.triageMaxTurnsTrivial/Moderate/Complex removed — maxTurns always sourced from config.defaultMaxTurns"
     - kind: added
-      description: "Helpers github-app-playground.image.orchestrator / .daemon resolve per-role image strings"
+      description: "config.ephemeralDaemon block: idleTimeoutMs, spawnCooldownMs, spawnQueueThreshold, namespace, image, orchestratorPublicUrl — configures orchestrator-spawned ephemeral daemon Pods"
     - kind: changed
-      description: "JOB_IMAGE (agentJobMode=isolated-job) now defaults to the daemon variant"
+      description: "BREAKING: rbac.create now provisions a Role for spawning Pods (ephemeral daemons) instead of Jobs. Same flag, new verbs scope."

--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.6.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.0"
+appVersion: "1.2.1"
 
 kubeVersion: ">= 1.31.0"
 
@@ -45,7 +45,7 @@ annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
     - kind: changed
-      description: "BREAKING: bump appVersion to 1.3.0 (upstream PR #35 collapses dispatch surface to daemon-only)"
+      description: "BREAKING: bump appVersion to 1.2.1 (upstream PR #35 collapses dispatch surface to daemon-only)"
     - kind: removed
       description: "BREAKING: config.agentJobMode and config.defaultDispatchTarget removed — dispatch is daemon-only"
     - kind: removed

--- a/charts/github-app-playground/ci/daemon-pools-values.yaml
+++ b/charts/github-app-playground/ci/daemon-pools-values.yaml
@@ -1,6 +1,3 @@
-config:
-  agentJobMode: daemon
-
 postgres:
   enabled: true
 

--- a/charts/github-app-playground/templates/NOTES.txt
+++ b/charts/github-app-playground/templates/NOTES.txt
@@ -1,4 +1,4 @@
-Upgrading from chart 0.5.x? (BREAKING — chart 0.6.0 / appVersion 1.3.0)
+Upgrading from chart 0.5.x? (BREAKING — chart 0.6.0 / appVersion 1.2.1)
   Upstream PR #35 collapses the dispatch surface to daemon-only. Remove
   these keys from your override values before `helm upgrade`:
     config.agentJobMode                config.triageMaxTurnsTrivial
@@ -17,9 +17,8 @@ Upgrading from chart 0.5.x? (BREAKING — chart 0.6.0 / appVersion 1.3.0)
       orchestratorPublicUrl (ws:// or wss://)
   rbac.create now provisions a Role for Pod spawning (was Jobs). Same flag,
   new verbs scope — `helm upgrade` applies the swap automatically.
-  NOTE: requires chrisleekr/github-app-playground:1.3.0-{orchestrator,daemon}
-  images upstream. If those tags are not yet published, pin image.*.tag to
-  a post-PR-#35 build or delay the upgrade.
+  NOTE: requires chrisleekr/github-app-playground:1.2.1-{orchestrator,daemon}
+  images upstream (published).
   See Chart.yaml artifacthub.io/changes annotation for the full list.
 
 1. Get the application URL by running these commands:

--- a/charts/github-app-playground/templates/NOTES.txt
+++ b/charts/github-app-playground/templates/NOTES.txt
@@ -1,12 +1,25 @@
-Upgrading from chart 0.4.x?
-  - Remove image.tag. Leave image.orchestrator.tag / image.daemon.tag empty
-    to default to <appVersion>-orchestrator / <appVersion>-daemon, or set
-    complete role tags — the chart does NOT append -orchestrator/-daemon to
-    user-supplied overrides.
-  - The chart no longer ships sharedRunner Deployment/Service. If you use
-    agentJobMode=shared-runner, host the runner yourself and point
-    config.internalRunnerUrl at it (SHARED_RUNNER_TOKEN is still rendered
-    in the app Secret for wire-protocol auth).
+Upgrading from chart 0.5.x? (BREAKING — chart 0.6.0 / appVersion 1.3.0)
+  Upstream PR #35 collapses the dispatch surface to daemon-only. Remove
+  these keys from your override values before `helm upgrade`:
+    config.agentJobMode                config.triageMaxTurnsTrivial
+    config.defaultDispatchTarget       config.triageMaxTurnsModerate
+    config.internalRunnerUrl           config.triageMaxTurnsComplex
+    config.jobNamespace                config.maxConcurrentIsolatedJobs
+    config.jobImage                    config.pendingIsolatedJobQueueMax
+    config.jobTtlSeconds               config.jobMaxCostUsd
+    config.jobActiveDeadlineSeconds    secrets.internalRunnerToken
+    config.jobWatchPollIntervalMs      secrets.sharedRunnerToken
+  New block (optional; sensible defaults):
+    config.ephemeralDaemon:
+      idleTimeoutMs, spawnCooldownMs, spawnQueueThreshold,
+      namespace (defaults to release namespace),
+      image (defaults to the daemon image),
+      orchestratorPublicUrl (ws:// or wss://)
+  rbac.create now provisions a Role for Pod spawning (was Jobs). Same flag,
+  new verbs scope — `helm upgrade` applies the swap automatically.
+  NOTE: requires chrisleekr/github-app-playground:1.3.0-{orchestrator,daemon}
+  images upstream. If those tags are not yet published, pin image.*.tag to
+  a post-PR-#35 build or delay the upgrade.
   See Chart.yaml artifacthub.io/changes annotation for the full list.
 
 1. Get the application URL by running these commands:
@@ -34,20 +47,14 @@ Upgrading from chart 0.4.x?
 2. Configure your GitHub App webhook to POST to:
    <your-ingress-host>/api/github/webhooks
 
-3. Current dispatch mode: {{ .Values.config.agentJobMode }}
-{{- if eq .Values.config.agentJobMode "inline" }}
-   Runs agent in-process. No data-layer infra required.
-{{- else }}
+3. Dispatch: daemon-only. The orchestrator enqueues jobs and dispatches them
+   to the persistent daemon pool; on heavy/overflow signals it spawns
+   ephemeral daemon Pods directly (see config.ephemeralDaemon.*).
    Requires DATABASE_URL, VALKEY_URL, DAEMON_AUTH_TOKEN (auto-wired when
    postgres.enabled / valkey.enabled, or auto-generated for the token).
-{{- if or (eq .Values.config.agentJobMode "isolated-job") (eq .Values.config.agentJobMode "auto") }}
-   isolated-job spawning also requires rbac.create=true.
-{{- end }}
-{{- if or (eq .Values.config.agentJobMode "shared-runner") (eq .Values.config.agentJobMode "auto") }}
-   shared-runner also requires config.internalRunnerUrl and the target
-   runner to expose POST /internal/run (NOTE: not yet shipped in the app image).
-{{- end }}
-{{- end }}
+   Ephemeral spawning additionally requires rbac.create=true so the
+   orchestrator ServiceAccount can create/get/delete Pods in
+   config.ephemeralDaemon.namespace (defaults to the release namespace).
 
 4. Verify the bot is healthy:
    kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ include "github-app-playground.name" . }}"
@@ -56,7 +63,7 @@ Upgrading from chart 0.4.x?
    kubectl --namespace {{ .Release.Namespace }} logs -f deploy/{{ include "github-app-playground.fullname" . }} \
      | jq 'select(.msg | test("dispatch decision|triage"))'
 
-DAEMON POOLS (config.agentJobMode must be daemon, shared-runner, or auto):
+DAEMON POOLS:
    Deploy one or more stateless daemon pools alongside the orchestrator:
 
      daemon:
@@ -76,17 +83,7 @@ DAEMON POOLS (config.agentJobMode must be daemon, shared-runner, or auto):
        | grep 'daemon:registered'
 
    Required: Postgres + Valkey must be reachable (postgres.enabled / valkey.enabled
-   or external) when agentJobMode is non-inline.
-
-UPGRADING from chart 0.3.x to 0.4.0:
-   Non-breaking: daemon.pools defaults to {} (no daemon Deployments).
-   The orchestrator Service gains a `ws` port (config.wsPort, default 3002)
-   only when config.agentJobMode is non-inline or daemon.pools is non-empty.
-   The Service selector now includes app.kubernetes.io/component: orchestrator;
-   helm upgrade restarts orchestrator pods with the new label automatically.
-   If you restrict pod ingress via NetworkPolicy, add a rule permitting traffic
-   on the ws port (config.wsPort, default 3002) when using non-inline mode.
-   No existing values need to change.
+   or external).
 
 UPGRADING from chart 0.2.x to 0.3.0 (breaking):
    Chart 0.3.0 splits `config:` into two top-level blocks. Every sensitive
@@ -106,8 +103,6 @@ UPGRADING from chart 0.2.x to 0.3.0 (breaking):
      config.awsSessionToken         -> secrets.awsSessionToken
      config.awsBearerTokenBedrock   -> secrets.awsBearerTokenBedrock
      config.context7ApiKey          -> secrets.context7ApiKey
-     config.internalRunnerToken     -> secrets.internalRunnerToken
-     config.sharedRunnerToken       -> secrets.sharedRunnerToken
      config.daemonAuthToken         -> secrets.daemonAuthToken
      config.databaseUrl             -> secrets.databaseUrl
      config.valkeyUrl               -> secrets.valkeyUrl

--- a/charts/github-app-playground/templates/_helpers.tpl
+++ b/charts/github-app-playground/templates/_helpers.tpl
@@ -319,7 +319,7 @@ Args (dict): root (.), repoOverride (string, optional), tagOverride (string, opt
 
 {{/*
 Daemon-variant image (repository:tag). Used by daemon pool Deployments and
-the isolated-job JOB_IMAGE fallback. Precedence mirrors .image.orchestrator.
+the ephemeral-daemon DAEMON_IMAGE fallback. Precedence mirrors .image.orchestrator.
 Args (dict): root (.), repoOverride (string, optional), tagOverride (string, optional).
 */}}
 {{- define "github-app-playground.image.daemon" -}}

--- a/charts/github-app-playground/templates/configmap.yaml
+++ b/charts/github-app-playground/templates/configmap.yaml
@@ -47,30 +47,10 @@ data:
   ALLOWED_OWNERS: {{ $c.allowedOwners | quote }}
   {{- end }}
 
-  # --- 6. Dispatch mode ---
-  AGENT_JOB_MODE: {{ $c.agentJobMode | quote }}
-  DEFAULT_DISPATCH_TARGET: {{ $c.defaultDispatchTarget | quote }}
-
-  # --- 7. K8s Job spawner (isolated-job target) ---
-  # JOB_NAMESPACE falls back to the release namespace when the user leaves it empty,
-  # so isolated-job pods land next to the release by default.
-  JOB_NAMESPACE: {{ default .Release.Namespace $c.jobNamespace | quote }}
-  # JOB_IMAGE falls back to the daemon variant (isolated-job Pods run the agent workload and need the CLI toolchain).
-  JOB_IMAGE: {{ default (include "github-app-playground.image.daemon" (dict "root" .)) $c.jobImage | quote }}
-  JOB_TTL_SECONDS: {{ $c.jobTtlSeconds | quote }}
-  JOB_ACTIVE_DEADLINE_SECONDS: {{ $c.jobActiveDeadlineSeconds | quote }}
-  JOB_WATCH_POLL_INTERVAL_MS: {{ $c.jobWatchPollIntervalMs | quote }}
-
-  # --- 8. Shared-runner HTTP target ---
-  {{- if $c.internalRunnerUrl }}
-  INTERNAL_RUNNER_URL: {{ $c.internalRunnerUrl | quote }}
-  {{- end }}
-
-  # --- 10. Orchestrator ---
+  # --- 6. Orchestrator ---
   WS_PORT: {{ $c.wsPort | quote }}
-  JOB_MAX_COST_USD: {{ $c.jobMaxCostUsd | quote }}
 
-  # --- 11. Daemon / Orchestrator WebSocket ---
+  # --- 7. Daemon / Orchestrator WebSocket ---
   {{- if $c.orchestratorUrl }}
   {{- fail "config.orchestratorUrl must not be set on the orchestrator — presence of ORCHESTRATOR_URL flips it into daemon mode. Use daemon.orchestratorUrl or per-pool daemon.pools.<name>.orchestratorUrl instead." }}
   {{- end }}
@@ -82,23 +62,28 @@ data:
   OFFER_TIMEOUT_MS: {{ $c.offerTimeoutMs | quote }}
   DAEMON_UPDATE_STRATEGY: {{ $c.daemonUpdateStrategy | quote }}
   DAEMON_UPDATE_DELAY_MS: {{ $c.daemonUpdateDelayMs | quote }}
-  DAEMON_EPHEMERAL: {{ $c.daemonEphemeral | quote }}
   DAEMON_MEMORY_FLOOR_MB: {{ $c.daemonMemoryFloorMb | quote }}
   DAEMON_DISK_FLOOR_MB: {{ $c.daemonDiskFloorMb | quote }}
 
-  # --- 12. Triage pre-classifier ---
+  # --- 8. Ephemeral daemon (K8s-spawned scale-up) ---
+  # The orchestrator itself is never ephemeral; only orchestrator-spawned Pods
+  # set DAEMON_EPHEMERAL=true on their own container spec.
+  DAEMON_EPHEMERAL: "false"
+  EPHEMERAL_DAEMON_IDLE_TIMEOUT_MS: {{ $c.ephemeralDaemon.idleTimeoutMs | quote }}
+  EPHEMERAL_DAEMON_SPAWN_COOLDOWN_MS: {{ $c.ephemeralDaemon.spawnCooldownMs | quote }}
+  EPHEMERAL_DAEMON_SPAWN_QUEUE_THRESHOLD: {{ $c.ephemeralDaemon.spawnQueueThreshold | quote }}
+  EPHEMERAL_DAEMON_NAMESPACE: {{ default .Release.Namespace $c.ephemeralDaemon.namespace | quote }}
+  DAEMON_IMAGE: {{ default (include "github-app-playground.image.daemon" (dict "root" .)) $c.ephemeralDaemon.image | quote }}
+  {{- if $c.ephemeralDaemon.orchestratorPublicUrl }}
+  ORCHESTRATOR_PUBLIC_URL: {{ $c.ephemeralDaemon.orchestratorPublicUrl | quote }}
+  {{- end }}
+
+  # --- 9. Triage (binary heavy classifier) ---
   TRIAGE_ENABLED: {{ $c.triageEnabled | quote }}
   TRIAGE_MODEL: {{ $c.triageModel | quote }}
   TRIAGE_CONFIDENCE_THRESHOLD: {{ $c.triageConfidenceThreshold | quote }}
   TRIAGE_MAX_TOKENS: {{ $c.triageMaxTokens | quote }}
   TRIAGE_TIMEOUT_MS: {{ $c.triageTimeoutMs | quote }}
 
-  # --- 13. Complexity → maxTurns mapping ---
-  TRIAGE_MAXTURNS_TRIVIAL: {{ $c.triageMaxTurnsTrivial | quote }}
-  TRIAGE_MAXTURNS_MODERATE: {{ $c.triageMaxTurnsModerate | quote }}
-  TRIAGE_MAXTURNS_COMPLEX: {{ $c.triageMaxTurnsComplex | quote }}
+  # --- 10. Agent max turns ---
   DEFAULT_MAXTURNS: {{ $c.defaultMaxTurns | quote }}
-
-  # --- 14. Isolated-job capacity back-pressure ---
-  MAX_CONCURRENT_ISOLATED_JOBS: {{ $c.maxConcurrentIsolatedJobs | quote }}
-  PENDING_ISOLATED_JOB_QUEUE_MAX: {{ $c.pendingIsolatedJobQueueMax | quote }}

--- a/charts/github-app-playground/templates/daemon-deployment.yaml
+++ b/charts/github-app-playground/templates/daemon-deployment.yaml
@@ -1,9 +1,5 @@
-{{- $daemonPoolModes := list "daemon" "shared-runner" "auto" }}
 {{- range $poolName, $pool := $.Values.daemon.pools }}
 {{- if ne ($pool.enabled | toString) "false" }}
-{{- if not (has $.Values.config.agentJobMode $daemonPoolModes) }}
-{{- fail (printf "daemon.pools.%s requires config.agentJobMode to be daemon, shared-runner, or auto (got: %s)" $poolName $.Values.config.agentJobMode) }}
-{{- end }}
 {{- $poolCfg := $pool.config | default dict }}
 {{- $daemonCfg := $.Values.daemon.config }}
 {{- $drainMs := int (ternary $poolCfg.daemonDrainTimeoutMs $daemonCfg.daemonDrainTimeoutMs (hasKey $poolCfg "daemonDrainTimeoutMs")) }}
@@ -174,8 +170,6 @@ spec:
               value: {{ ternary $poolCfg.daemonUpdateStrategy $daemonCfg.daemonUpdateStrategy (hasKey $poolCfg "daemonUpdateStrategy") | quote }}
             - name: DAEMON_UPDATE_DELAY_MS
               value: {{ ternary $poolCfg.daemonUpdateDelayMs $daemonCfg.daemonUpdateDelayMs (hasKey $poolCfg "daemonUpdateDelayMs") | quote }}
-            - name: DAEMON_EPHEMERAL
-              value: {{ ternary $poolCfg.daemonEphemeral $daemonCfg.daemonEphemeral (hasKey $poolCfg "daemonEphemeral") | quote }}
             - name: DAEMON_MEMORY_FLOOR_MB
               value: {{ ternary $poolCfg.daemonMemoryFloorMb $daemonCfg.daemonMemoryFloorMb (hasKey $poolCfg "daemonMemoryFloorMb") | quote }}
             - name: DAEMON_DISK_FLOOR_MB

--- a/charts/github-app-playground/templates/role.yaml
+++ b/charts/github-app-playground/templates/role.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.rbac.create }}
+{{- $targetNs := .Values.config.ephemeralDaemon.namespace | default .Release.Namespace }}
+{{- if ne $targetNs .Release.Namespace }}
+{{- fail (printf "config.ephemeralDaemon.namespace=%q differs from the release namespace %q. The chart-managed Role grants Pod-spawn verbs only within the release namespace, so the orchestrator ServiceAccount will receive 403 when creating Pods in %q at runtime. Either leave config.ephemeralDaemon.namespace empty (defaults to the release namespace), or set rbac.create=false and provision a Role+RoleBinding in %q yourself." $targetNs .Release.Namespace $targetNs $targetNs) }}
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/github-app-playground/templates/role.yaml
+++ b/charts/github-app-playground/templates/role.yaml
@@ -6,12 +6,9 @@ metadata:
   labels:
     {{- include "github-app-playground.labels" . | nindent 4 }}
 rules:
-  # src/k8s/job-spawner.ts createNamespacedJob / readNamespacedJobStatus / deleteNamespacedJob
-  - apiGroups: ["batch"]
-    resources: ["jobs"]
-    verbs: ["create", "get", "list", "watch", "delete"]
-  # Spawner inspects pod status + optionally tails logs of the isolated-job pod
+  # src/k8s/ephemeral-daemon-spawner.ts creates bare Pods (restartPolicy: Never)
+  # as scale-up daemons, then polls their status until completion/reclaim.
   - apiGroups: [""]
-    resources: ["pods", "pods/log"]
-    verbs: ["get", "list", "watch"]
+    resources: ["pods"]
+    verbs: ["create", "get", "list", "watch", "delete"]
 {{- end }}

--- a/charts/github-app-playground/templates/secret.yaml
+++ b/charts/github-app-playground/templates/secret.yaml
@@ -51,11 +51,7 @@ data:
   CONTEXT7_API_KEY: {{ $s.context7ApiKey | b64enc | quote }}
   {{- end }}
 
-  # --- 8. Shared-runner HTTP target (auto-generated, stable via `lookup`) ---
-  INTERNAL_RUNNER_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "INTERNAL_RUNNER_TOKEN" "secretName" $appSecret "override" $s.internalRunnerToken "root" .) | b64enc | quote }}
-  SHARED_RUNNER_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "SHARED_RUNNER_TOKEN" "secretName" $appSecret "override" $s.sharedRunnerToken "root" .) | b64enc | quote }}
-
-  # --- 9. Data layer (auto-composed URLs from postgres.* / valkey.* resolution order) ---
+  # --- 7. Data layer (auto-composed URLs from postgres.* / valkey.* resolution order) ---
   {{- $dbUrl := include "github-app-playground.databaseUrl" . }}
   {{- if $dbUrl }}
   DATABASE_URL: {{ $dbUrl | b64enc | quote }}
@@ -65,6 +61,6 @@ data:
   VALKEY_URL: {{ $valkeyUrl | b64enc | quote }}
   {{- end }}
 
-  # --- 11. Daemon / Orchestrator WebSocket (auto-generated, stable via `lookup`) ---
+  # --- 8. Daemon / Orchestrator WebSocket (auto-generated, stable via `lookup`) ---
   DAEMON_AUTH_TOKEN: {{ include "github-app-playground.stableToken" (dict "key" "DAEMON_AUTH_TOKEN" "secretName" $appSecret "override" $s.daemonAuthToken "root" .) | b64enc | quote }}
 {{- end }}

--- a/charts/github-app-playground/templates/service.yaml
+++ b/charts/github-app-playground/templates/service.yaml
@@ -12,11 +12,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    {{- if or (ne .Values.config.agentJobMode "inline") .Values.daemon.pools }}
     - port: {{ .Values.config.wsPort }}
       targetPort: ws
       protocol: TCP
       name: ws
-    {{- end }}
   selector:
     {{- include "github-app-playground.selectorLabels" . | nindent 4 }}

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -27,16 +27,16 @@ fullnameOverride: ""
 
 serviceAccount:
   create: true
-  # Auto-mount the SA token so src/k8s/job-spawner.ts can call the Kubernetes API
-  # when config.agentJobMode is isolated-job or auto. Safe to leave true when RBAC
+  # Auto-mount the SA token so src/k8s/ephemeral-daemon-spawner.ts can call the
+  # Kubernetes API to create ephemeral daemon Pods. Safe to leave true when RBAC
   # is disabled: the token still grants nothing without a Role binding.
   automount: true
   annotations: {}                               # Add IRSA / cloud IAM bindings here.
   name: ""                                      # Leave empty to use the fullname template.
 
-# Role + RoleBinding for in-cluster Job spawning (isolated-job mode).
+# Role + RoleBinding for in-cluster ephemeral daemon Pod spawning.
 rbac:
-  create: false                                 # Set true when config.agentJobMode is isolated-job or auto.
+  create: false                                 # Set true to allow the orchestrator to spawn ephemeral daemon Pods.
 
 podAnnotations: {}
 podLabels: {}
@@ -284,15 +284,11 @@ secrets:
   # --- 5. App runtime / behaviour (secret subset) ---
   context7ApiKey: ""                            # Lifts the Context7 MCP rate limit. Unset works.
 
-  # --- 8. Shared-runner HTTP target (auto-generated, persisted across upgrades) ---
-  internalRunnerToken: ""                       # Leave empty to auto-generate and persist.
-  sharedRunnerToken: ""                         # ADR-011 reserved; leave empty to auto-generate.
-
-  # --- 9. Data layer (connection strings embed passwords → secret, not config) ---
+  # --- 7. Data layer (connection strings embed passwords → secret, not config) ---
   databaseUrl: ""                               # Leave empty to compose from postgres.* or postgres.external.*.
   valkeyUrl: ""                                 # Leave empty to compose from valkey.* or valkey.external.*.
 
-  # --- 11. Daemon / Orchestrator WebSocket (auto-generated, persisted across upgrades) ---
+  # --- 8. Daemon / Orchestrator WebSocket (auto-generated, persisted across upgrades) ---
   daemonAuthToken: ""                           # Leave empty to auto-generate and persist.
 
 # ─────────────────────────── APPLICATION CONFIG ───────────────────────
@@ -323,63 +319,52 @@ config:
   claudeCodePath: ""                            # Required only when claude-code is installed globally (e.g. Docker).
   allowedOwners: ""                             # Comma-separated. Required when secrets.claudeCodeOauthToken is set.
 
-  # --- 6. Dispatch mode (Phase 2+ / Phase 3) ---
-  agentJobMode: inline                          # inline | daemon | shared-runner | isolated-job | auto.
-  defaultDispatchTarget: shared-runner          # Cannot be inline when agentJobMode=auto.
-
-  # --- 7. K8s Job spawner (isolated-job target) ---
-  jobNamespace: ""                              # Leave empty to use the release namespace.
-  jobImage: ""                                  # Leave empty to inherit .Values.image.
-  jobTtlSeconds: 300
-  jobActiveDeadlineSeconds: 1800                # Zod caps at 3500 (installation-token TTL margin).
-  jobWatchPollIntervalMs: 5000
-
-  # --- 8. Shared-runner HTTP target (non-secret subset) ---
-  internalRunnerUrl: ""                         # Required when agentJobMode is shared-runner or auto.
-
-  # --- 10. Orchestrator ---
+  # --- 6. Orchestrator ---
   wsPort: 3002                                  # Must differ from config.port.
-  jobMaxCostUsd: 80                             # Placeholder today (not enforced in code).
 
-  # --- 11. Daemon / Orchestrator WebSocket (non-secret subset) ---
+  # --- 7. Daemon / Orchestrator WebSocket (non-secret subset) ---
   orchestratorUrl: ""                           # Setting this flips the process to DAEMON mode (webhook HTTP not started).
   heartbeatIntervalMs: 30000
   heartbeatTimeoutMs: 90000                     # Keep >= 2 x heartbeatIntervalMs.
   staleExecutionThresholdMs: 660000             # Must exceed agentTimeoutMs (600000).
   daemonDrainTimeoutMs: 600000                  # Set >= agentTimeoutMs to avoid mid-run kills on SIGTERM.
-  jobMaxRetries: 3                              # Daemon-dispatch retry only. isolated-job ignores this (FR-021).
+  jobMaxRetries: 3
   offerTimeoutMs: 5000
   daemonUpdateStrategy: exit                    # exit | pull | notify.
   daemonUpdateDelayMs: 0
-  daemonEphemeral: false                        # Placeholder today (not enforced in code).
   daemonMemoryFloorMb: 512
   daemonDiskFloorMb: 1024
 
-  # --- 12. Triage pre-classifier (auto mode) ---
+  # --- 8. Ephemeral daemon (K8s-spawned scale-up) ---
+  # The orchestrator spawns bare Pods (not Jobs) when triage reports `heavy`
+  # or the job queue crosses `spawnQueueThreshold`. Requires rbac.create=true
+  # so the orchestrator ServiceAccount can create/get/delete pods in
+  # `namespace`. See src/k8s/ephemeral-daemon-spawner.ts upstream.
+  ephemeralDaemon:
+    idleTimeoutMs: 120000                       # Ephemeral daemon exits after this much idle time. Zod caps at 3_000_000 (below K8s 3600s activeDeadline with 10-min safety margin).
+    spawnCooldownMs: 30000                      # Minimum interval between spawns. Prevents burst storms.
+    spawnQueueThreshold: 3                      # Queue depth that triggers overflow spawn when persistent pool is saturated.
+    namespace: ""                               # Leave empty to use the release namespace. Sets EPHEMERAL_DAEMON_NAMESPACE.
+    image: ""                                   # Leave empty to use the daemon image helper. Sets DAEMON_IMAGE.
+    orchestratorPublicUrl: ""                   # Optional ws:// or wss:// URL ephemeral daemons dial back. Unset OK when spawned Pods can reach the in-cluster orchestrator Service.
+
+  # --- 9. Triage (binary heavy classifier) ---
   triageEnabled: true                           # Kill-switch for the triage LLM call.
   triageModel: haiku-3-5
   triageConfidenceThreshold: 1.0                # Lower to 0.75 only after SC-003/SC-004 stabilise.
   triageMaxTokens: 256
   triageTimeoutMs: 5000
 
-  # --- 13. Complexity → maxTurns mapping (FR-008a) ---
-  triageMaxTurnsTrivial: 10
-  triageMaxTurnsModerate: 30
-  triageMaxTurnsComplex: 50
-  defaultMaxTurns: 30
-
-  # --- 14. Isolated-job capacity back-pressure (FR-018, US3) ---
-  maxConcurrentIsolatedJobs: 3
-  pendingIsolatedJobQueueMax: 20
+  # --- 10. Agent max turns ---
+  defaultMaxTurns: 30                           # maxTurns is always sourced from this value (triage-derived turns removed).
 
 # ─────────────────────────── DAEMON POOLS ─────────────────────────────
 # `daemon:` configures 0..N stateless daemon worker pools. Each pool
 # renders its own Deployment. Daemons connect outbound to the orchestrator
 # WebSocket on :config.wsPort and register via a shared DAEMON_AUTH_TOKEN.
 #
-# The orchestrator's Service gains a `ws` port when any pool is defined
-# (or when config.agentJobMode is non-inline), so daemons can reach it at
-# ws://<fullname>:<config.wsPort>/ws.
+# The orchestrator's Service exposes a `ws` port (config.wsPort) so
+# daemons can reach it at ws://<fullname>:<config.wsPort>/ws.
 #
 # All pools share the same Docker image (default CMD overridden to daemon
 # entry point) and the same app Secret (for DAEMON_AUTH_TOKEN and AI keys).
@@ -402,7 +387,6 @@ daemon:
     offerTimeoutMs: 5000               # OFFER_TIMEOUT_MS
     daemonUpdateStrategy: exit         # exit | pull | notify
     daemonUpdateDelayMs: 0             # DAEMON_UPDATE_DELAY_MS
-    daemonEphemeral: false             # DAEMON_EPHEMERAL
     daemonMemoryFloorMb: 512           # DAEMON_MEMORY_FLOOR_MB
     daemonDiskFloorMb: 1024            # DAEMON_DISK_FLOOR_MB
 

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -12,7 +12,7 @@ replicaCount: 1
 # pins (e.g. per-image digest), independent rollouts, and correct role→image
 # mapping without relying on the upstream <tag>=orchestrator compat alias.
 #   <repo>:<tag>-orchestrator  webhook Deployment
-#   <repo>:<tag>-daemon        daemon pool Deployments + isolated-job Pods
+#   <repo>:<tag>-daemon        daemon pool Deployments + ephemeral daemon Pods
 image:
   repository: chrisleekr/github-app-playground
   pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

Apply upstream [chrisleekr/github-app-playground#35](https://github.com/chrisleekr/github-app-playground/pull/35) (merged 2026-04-20) to this chart. The upstream refactor removes the `inline | shared-runner | isolated-job | auto` dispatch modes and leaves a single **daemon-only** path: the orchestrator enqueues work, dispatches to the persistent daemon pool, and (when heavy/overflow) spawns ephemeral daemon **Pods** directly — no more `batch/jobs`, no more shared-runner HTTP dispatchers.

Chart `0.5.0 → 0.6.0` (breaking), `appVersion 1.2.0 → 1.2.1`. Upstream cut `1.2.1` (not `1.3.0`) with PR #35 included — `chrisleekr/github-app-playground:1.2.1-orchestrator` and `:1.2.1-daemon` are published on Docker Hub, so `helm install` resolves cleanly.

### Before

```mermaid
flowchart LR
  classDef keep fill:#1f6feb,stroke:#0b3a85,color:#ffffff
  classDef drop fill:#b1361e,stroke:#5a1a0b,color:#ffffff
  Orch["orchestrator"]:::keep
  Orch --> Inline["inline"]:::drop
  Orch --> Daemon["daemon pool"]:::keep
  Orch --> Shared["shared-runner HTTP"]:::drop
  Orch --> Jobs["batch/Jobs isolated"]:::drop
  Daemon --> Pool["persistent daemons"]:::keep
```

### After

```mermaid
flowchart LR
  classDef keep fill:#1f6feb,stroke:#0b3a85,color:#ffffff
  classDef add fill:#1a7f37,stroke:#0b4d1f,color:#ffffff
  Orch["orchestrator"]:::keep
  Orch --> Daemon["daemon pool"]:::keep
  Orch -->|spawn Pod| Eph["ephemeral daemon Pod"]:::add
  Daemon --> Pool["persistent daemons"]:::keep
```

## Changes

### Chart metadata
- `Chart.yaml`: `version: 0.6.0`, `appVersion: "1.2.1"`, full `artifacthub.io/changes` rewrite for the breaking release.

### values.yaml
- **Removed 13 `config.*` keys**: `agentJobMode`, `defaultDispatchTarget`, `internalRunnerUrl`, `jobNamespace`, `jobImage`, `jobTtlSeconds`, `jobActiveDeadlineSeconds`, `jobWatchPollIntervalMs`, `jobMaxCostUsd`, `triageMaxTurnsTrivial/Moderate/Complex`, `maxConcurrentIsolatedJobs`, `pendingIsolatedJobQueueMax`.
- **Removed 2 `secrets.*` keys**: `internalRunnerToken`, `sharedRunnerToken`.
- **Removed** `daemon.config.daemonEphemeral` (persistent pools never are).
- **Added** `config.ephemeralDaemon:` block with `idleTimeoutMs`, `spawnCooldownMs`, `spawnQueueThreshold`, `namespace`, `image`, `orchestratorPublicUrl`.

### Templates
- `configmap.yaml`: dead dispatch/job env vars removed; emits `DAEMON_EPHEMERAL=false` plus `EPHEMERAL_DAEMON_*`, `DAEMON_IMAGE` (fallback to daemon image helper), and `ORCHESTRATOR_PUBLIC_URL` when set.
- `secret.yaml`: `INTERNAL_RUNNER_TOKEN` / `SHARED_RUNNER_TOKEN` emissions removed.
- `role.yaml`: `rbac.create` now provisions a single rule `apiGroups: [""], resources: ["pods"], verbs: [create,get,list,watch,delete]` (was `batch/jobs` + `pods/log`). Same flag, new verb scope.
- `daemon-deployment.yaml`: removed the `agentJobMode` validation guard and the per-pool `DAEMON_EPHEMERAL` env.
- `service.yaml`: ws port always rendered (dropped the `agentJobMode != inline` gate).
- `NOTES.txt`: prepended 0.5.x → 0.6.0 migration section; step 3 rewritten as a daemon-only paragraph; obsolete 0.3.x → 0.4.0 block removed; stale secret keys pruned from the 0.2.x → 0.3.0 rename table.

### CI
- `.github/workflows/lint.yml`: dropped every `--set config.agentJobMode=` / `--set config.internalRunnerUrl=` / `--set config.defaultDispatchTarget=`; added an ephemeral-spawn scenario (`rbac.create=true` + `config.ephemeralDaemon.orchestratorPublicUrl=ws://…`).
- `ci/daemon-pools-values.yaml`: removed top-level `config.agentJobMode: daemon`.

## Verification

- `helm lint charts/github-app-playground` — clean.
- All 7 `helm template` scenarios from lint.yml render without error.
- `helm template … | grep -E '(AGENT_JOB_MODE|JOB_IMAGE|INTERNAL_RUNNER|DEFAULT_DISPATCH|TRIAGE_MAXTURNS_|MAX_CONCURRENT_ISOLATED|PENDING_ISOLATED|JOB_MAX_COST|JOB_TTL|JOB_ACTIVE_DEADLINE|JOB_WATCH_POLL)'` → 0 matches.
- Ephemeral-spawn render: `EPHEMERAL_DAEMON_*`, `DAEMON_IMAGE`, `ORCHESTRATOR_PUBLIC_URL`, and the pods-scoped Role all present.
- Docker Hub: `chrisleekr/github-app-playground:1.2.1`, `:1.2.1-orchestrator`, `:1.2.1-daemon` all published.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Dispatch model now daemon-only; removed multi-mode dispatch configuration
  * Isolated job and shared runner settings removed from chart
  * RBAC requirements updated for daemon Pod spawning instead of Job spawning

* **New Features**
  * Added ephemeral daemon spawning with configurable idle timeout, spawn cooldown, queue threshold, namespace, image, and public URL

* **Chores**
  * Bumped Helm chart version to 0.6.0 (appVersion 1.2.1)
  * Simplified configuration by removing deprecated deployment options
  * Updated upgrade notes and deployment guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->