### PR TITLE
fix(github-app-playground): bump appVersion to 1.2.2 for Valkey readiness race fix (v0.6.1)

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -1,6 +1,8 @@
 apiVersion: v2
 name: github-app-playground
-description: A Helm chart for GitHub App that responds to @chrisleekr-bot mentions on PRs and issues, using Claude Agent SDK with MCP servers for GitHub interactions.
+description: A Helm chart for GitHub App that responds to @chrisleekr-bot
+  mentions on PRs and issues, using Claude Agent SDK with MCP servers for GitHub
+  interactions.
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.1"
+appVersion: "1.2.2"
 
 kubeVersion: ">= 1.31.0"
 
@@ -44,17 +46,5 @@ sources:
 annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
-    - kind: changed
-      description: "BREAKING: bump appVersion to 1.2.1 (upstream PR #35 collapses dispatch surface to daemon-only)"
-    - kind: removed
-      description: "BREAKING: config.agentJobMode and config.defaultDispatchTarget removed — dispatch is daemon-only"
-    - kind: removed
-      description: "BREAKING: config.internalRunnerUrl and secrets.internalRunnerToken/sharedRunnerToken removed (shared-runner target gone)"
-    - kind: removed
-      description: "BREAKING: config.jobNamespace/jobImage/jobTtlSeconds/jobActiveDeadlineSeconds/jobWatchPollIntervalMs/jobMaxCostUsd/maxConcurrentIsolatedJobs/pendingIsolatedJobQueueMax removed (isolated-job target gone)"
-    - kind: removed
-      description: "BREAKING: config.triageMaxTurnsTrivial/Moderate/Complex removed — maxTurns always sourced from config.defaultMaxTurns"
-    - kind: added
-      description: "config.ephemeralDaemon block: idleTimeoutMs, spawnCooldownMs, spawnQueueThreshold, namespace, image, orchestratorPublicUrl — configures orchestrator-spawned ephemeral daemon Pods"
-    - kind: changed
-      description: "BREAKING: rbac.create now provisions a Role for spawning Pods (ephemeral daemons) instead of Jobs. Same flag, new verbs scope."
+    - kind: fixed
+      description: "bump appVersion to 1.2.2 (upstream PR #37 awaits Valkey connect before flipping /readyz, eliminating startup probe 503 race)"

--- a/charts/github-app-playground/templates/NOTES.txt
+++ b/charts/github-app-playground/templates/NOTES.txt
@@ -1,4 +1,4 @@
-Upgrading from chart 0.5.x? (BREAKING — chart 0.6.0 / appVersion 1.2.1)
+Upgrading from chart 0.5.x? (BREAKING — chart 0.6.0+ / appVersion 1.2.2)
   Upstream PR #35 collapses the dispatch surface to daemon-only. Remove
   these keys from your override values before `helm upgrade`:
     config.agentJobMode                config.triageMaxTurnsTrivial
@@ -17,7 +17,7 @@ Upgrading from chart 0.5.x? (BREAKING — chart 0.6.0 / appVersion 1.2.1)
       orchestratorPublicUrl (ws:// or wss://)
   rbac.create now provisions a Role for Pod spawning (was Jobs). Same flag,
   new verbs scope — `helm upgrade` applies the swap automatically.
-  NOTE: requires chrisleekr/github-app-playground:1.2.1-{orchestrator,daemon}
+  NOTE: requires chrisleekr/github-app-playground:1.2.2-{orchestrator,daemon}
   images upstream (published).
   See Chart.yaml artifacthub.io/changes annotation for the full list.
 


### PR DESCRIPTION
## Summary                                                                                           
                                                                                                                                                                                                              
  Patch release of the `github-app-playground` chart (0.6.0 → 0.6.1) that pins the upstream image bump to `1.2.2`. Upstream [chrisleekr/github-app-playground#37](https://github.com/chrisleekr/github-app-playground/pull/37) awaits the Valkey `client.connect()` (with a 15s timeout) before the orchestrator flips `isReady`, eliminating a startup race where `/readyz` returned 503 until Bun's `onconnect` fired on a later event-loop tick — long enough to trip the K8s `failureThreshold` and cause restart loops.                    
                                                                                                       
  No chart-surface changes: no new values keys, no template changes, no RBAC changes. The image tag helpers default to `{{ .Chart.AppVersion }}-{orchestrator,daemon}`, so bumping `appVersion` rolls both variant images automatically.                                                                                                                                                                               
                                                                                                                                                                                                                
  ### Before — startup probe race                                                                      
                                                                               
  ```mermaid                                                                                                                                                                                                  
  sequenceDiagram
      participant App as runStartupChecks                                                                                                                                                                       
      participant RC as Bun RedisClient
      participant Probe as K8s /readyz                                                                                                                                                                          
      App->>RC: new RedisClient                                                                        
      App->>App: isReady = true                                                                                                                                                                                 
      Probe->>App: GET /readyz                                                                                                                                                                                
      App-->>Probe: 503 valkeyConnected=false                                                                                                                                                                   
      Note over Probe: failureThreshold ticks up                                                                                                                                                                
      RC-->>App: onconnect fires on later tick                                                                                                                                                                  
      App->>App: valkeyConnected = true                                                                                                                                                                         
      Probe->>App: GET /readyz                                                                                                                                                                                  
      App-->>Probe: 200                                                                                                                                                                                       
  ```                                                                                                                                                                                                           
                                                                                                                                                                                                              
  ### After — awaited connect                                                                                                                                                                                   
                                                                                                                                                                                                              
  ```mermaid                                                                                                                                                                                                    
  sequenceDiagram                                                                                      
      participant App as runStartupChecks                                      
      participant RC as Bun RedisClient                                                                                                                                                                       
      participant Probe as K8s /readyz
      App->>RC: new RedisClient                                                                                                                                                                                 
      App->>RC: await client.connect race 15s timeout
      RC-->>App: onconnect fires                                                                                                                                                                                
      RC-->>App: connect resolves                                                                      
      App->>App: isReady = true                                                                                                                                                                                 
      Probe->>App: GET /readyz                                                                                                                                                                                  
      App-->>Probe: 200                                                        
  ```                                                                                                                                                                                                           
                                                                                                       
  ## Changes                                                                   
                                                                                                                                                                                                              
  - **`charts/github-app-playground/Chart.yaml`**                                                                                                                                                               
    - Bump chart `version` `0.6.0` → `0.6.1`.
    - Bump `appVersion` `"1.2.1"` → `"1.2.2"` (picks up upstream PR #37 in both orchestrator and daemon images via the existing `{{ .Chart.AppVersion }}-{orchestrator,daemon}` default).                       
    - Replace the carried-over v0.6.0 `artifacthub.io/changes` list with a single `kind: fixed` entry describing the Valkey readiness fix (annotation is per-release, not cumulative).                          
    - Cosmetic YAML reflow of the `description:` string (editor line-wrap; no content change).                                                                                                                  
  - **`charts/github-app-playground/templates/NOTES.txt`**                                                                                                                                                      
    - Update the 0.5.x → 0.6.x upgrade header reference from `chart 0.6.0 / appVersion 1.2.1` to `chart 0.6.0+ / appVersion 1.2.2`.                                                                             
    - Bump the required-image note from `1.2.1-{orchestrator,daemon}` to `1.2.2-{orchestrator,daemon}`.                                                                                                         
                                                                                                                                                                                                                
  ## Verification                                                                                                                                                                                               
                                                                                                                                                                                                                
  - `helm lint charts/github-app-playground` → 0 failures (pre-existing `icon` INFO only).                                                                                                                      
  - `helm template` renders `app.kubernetes.io/version: "1.2.2"` on all workloads; image tag helpers resolve to `...:1.2.2-orchestrator` / `...:1.2.2-daemon`.                                                
  - Upstream PR #37 introduces no new env vars / config keys / ports, so no `values.yaml`, ConfigMap, or Secret changes are required.    
