### PR TITLE
feat(github-app-playground): bump to v1.3.0, expose new orchestrator tunables, fix daemon drain (v0.7.0)

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.2"
+appVersion: "1.3.0"
 
 kubeVersion: ">= 1.31.0"
 
@@ -46,5 +46,23 @@ sources:
 annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "bump appVersion to 1.2.2 (upstream PR #37 awaits Valkey connect before flipping /readyz, eliminating startup probe 503 race)"
+    - kind: changed
+      description: "bump appVersion to 1.3.0 (upstream v1.3.0: label-dispatched bot workflow foundation, review handler streams progress, end-to-end runs no longer lose progress to mid-run caps)"
+    - kind: changed
+      description: "config.agentTimeoutMs default 600000 → 3600000 (upstream src/config.ts: 60min wall-clock cap; non-trivial implement/review steps routinely run 30-50min)"
+    - kind: changed
+      description: "config.staleExecutionThresholdMs default 660000 → 3660000 (must stay ≥ agentTimeoutMs; preserves 60s margin)"
+    - kind: changed
+      description: "config.daemonDrainTimeoutMs default 600000 → 3600000 (must stay ≥ agentTimeoutMs to avoid SIGTERM mid-run kills)"
+    - kind: changed
+      description: "daemon.config.staleExecutionThresholdMs and daemon.config.daemonDrainTimeoutMs defaults bumped to match orchestrator"
+    - kind: changed
+      description: "config.triageModel default haiku-3-5 → haiku-4-5 (upstream default refresh)"
+    - kind: changed
+      description: "config.defaultMaxTurns default 30 → \"\" (unset; upstream switched to optional — set only when ops needs a hard ceiling)"
+    - kind: added
+      description: "config.queueWorkerBackoffMaxMs (QUEUE_WORKER_BACKOFF_MAX_MS, default 5000): caps the queue-worker re-push backoff when no local daemon is capable"
+    - kind: added
+      description: "config.livenessReaperIntervalMs (LIVENESS_REAPER_INTERVAL_MS, default 30000, min 20000): cadence of the heartbeat-based liveness reaper that fails workflow_runs whose owner heartbeat is missing"
+    - kind: added
+      description: "config.intentConfidenceThreshold (INTENT_CONFIDENCE_THRESHOLD, default 0.75): minimum classifier confidence before dispatching; below this the bot posts a clarification request instead"

--- a/charts/github-app-playground/templates/NOTES.txt
+++ b/charts/github-app-playground/templates/NOTES.txt
@@ -1,4 +1,34 @@
-Upgrading from chart 0.5.x? (BREAKING — chart 0.6.0+ / appVersion 1.2.2)
+Upgrading from chart 0.6.x? (chart 0.7.0 / appVersion 1.3.0)
+  Upstream v1.3.0 ships label-dispatched bot workflows, review-handler
+  progress streaming, and end-to-end runs that no longer lose progress to
+  mid-run turn caps. The chart bumps defaults to match upstream and exposes
+  three new tunables.
+
+  Default changes (rolling without overrides will adopt the new values):
+    config.agentTimeoutMs            600000  → 3600000   (10min → 60min)
+    config.staleExecutionThresholdMs 660000  → 3660000   (≥ agentTimeoutMs)
+    config.daemonDrainTimeoutMs      600000  → 3600000   (≥ agentTimeoutMs)
+    daemon.config.staleExecutionThresholdMs / daemonDrainTimeoutMs — same.
+    config.triageModel               haiku-3-5 → haiku-4-5
+    config.defaultMaxTurns           30 → ""             (unset; no cap)
+
+  Operational impact of the drain bump:
+    Daemon Pod terminationGracePeriodSeconds is computed as
+    daemonDrainTimeoutMs/1000 + 30 (now ~3630s ≈ 60.5min). Confirm your
+    cluster (and any node-drain / PDB / spot-termination tooling) tolerates
+    long graceful shutdowns before rolling. Set
+    daemon.terminationGracePeriodSeconds explicitly to clamp it.
+
+  New optional env vars (sensible defaults; override under `config:`):
+    queueWorkerBackoffMaxMs   (QUEUE_WORKER_BACKOFF_MAX_MS, default 5000)
+    livenessReaperIntervalMs  (LIVENESS_REAPER_INTERVAL_MS, default 30000,
+                               min 20000)
+    intentConfidenceThreshold (INTENT_CONFIDENCE_THRESHOLD, default 0.75)
+
+  No values.yaml renames required. `helm upgrade` applies the changes; pin
+  any of the above in your override values to keep prior behaviour.
+
+UPGRADING from chart 0.5.x to 0.6.0 (BREAKING):
   Upstream PR #35 collapses the dispatch surface to daemon-only. Remove
   these keys from your override values before `helm upgrade`:
     config.agentJobMode                config.triageMaxTurnsTrivial
@@ -17,8 +47,6 @@ Upgrading from chart 0.5.x? (BREAKING — chart 0.6.0+ / appVersion 1.2.2)
       orchestratorPublicUrl (ws:// or wss://)
   rbac.create now provisions a Role for Pod spawning (was Jobs). Same flag,
   new verbs scope — `helm upgrade` applies the swap automatically.
-  NOTE: requires chrisleekr/github-app-playground:1.2.2-{orchestrator,daemon}
-  images upstream (published).
   See Chart.yaml artifacthub.io/changes annotation for the full list.
 
 1. Get the application URL by running these commands:

--- a/charts/github-app-playground/templates/configmap.yaml
+++ b/charts/github-app-playground/templates/configmap.yaml
@@ -60,8 +60,8 @@ data:
   DAEMON_DRAIN_TIMEOUT_MS: {{ int $c.daemonDrainTimeoutMs | quote }}
   JOB_MAX_RETRIES: {{ $c.jobMaxRetries | quote }}
   OFFER_TIMEOUT_MS: {{ $c.offerTimeoutMs | quote }}
-  QUEUE_WORKER_BACKOFF_MAX_MS: {{ $c.queueWorkerBackoffMaxMs | quote }}
-  LIVENESS_REAPER_INTERVAL_MS: {{ $c.livenessReaperIntervalMs | quote }}
+  QUEUE_WORKER_BACKOFF_MAX_MS: {{ int $c.queueWorkerBackoffMaxMs | quote }}
+  LIVENESS_REAPER_INTERVAL_MS: {{ int $c.livenessReaperIntervalMs | quote }}
   DAEMON_UPDATE_STRATEGY: {{ $c.daemonUpdateStrategy | quote }}
   DAEMON_UPDATE_DELAY_MS: {{ $c.daemonUpdateDelayMs | quote }}
   DAEMON_MEMORY_FLOOR_MB: {{ $c.daemonMemoryFloorMb | quote }}

--- a/charts/github-app-playground/templates/configmap.yaml
+++ b/charts/github-app-playground/templates/configmap.yaml
@@ -36,7 +36,7 @@ data:
   LOG_LEVEL: {{ $c.logLevel | quote }}
   NODE_ENV: {{ $c.nodeEnv | quote }}
   MAX_CONCURRENT_REQUESTS: {{ $c.maxConcurrentRequests | quote }}
-  AGENT_TIMEOUT_MS: {{ $c.agentTimeoutMs | quote }}
+  AGENT_TIMEOUT_MS: {{ int $c.agentTimeoutMs | quote }}
   {{- if ne ($c.agentMaxTurns | toString) "" }}
   AGENT_MAX_TURNS: {{ $c.agentMaxTurns | quote }}
   {{- end }}
@@ -56,10 +56,12 @@ data:
   {{- end }}
   HEARTBEAT_INTERVAL_MS: {{ $c.heartbeatIntervalMs | quote }}
   HEARTBEAT_TIMEOUT_MS: {{ $c.heartbeatTimeoutMs | quote }}
-  STALE_EXECUTION_THRESHOLD_MS: {{ $c.staleExecutionThresholdMs | quote }}
-  DAEMON_DRAIN_TIMEOUT_MS: {{ $c.daemonDrainTimeoutMs | quote }}
+  STALE_EXECUTION_THRESHOLD_MS: {{ int $c.staleExecutionThresholdMs | quote }}
+  DAEMON_DRAIN_TIMEOUT_MS: {{ int $c.daemonDrainTimeoutMs | quote }}
   JOB_MAX_RETRIES: {{ $c.jobMaxRetries | quote }}
   OFFER_TIMEOUT_MS: {{ $c.offerTimeoutMs | quote }}
+  QUEUE_WORKER_BACKOFF_MAX_MS: {{ $c.queueWorkerBackoffMaxMs | quote }}
+  LIVENESS_REAPER_INTERVAL_MS: {{ $c.livenessReaperIntervalMs | quote }}
   DAEMON_UPDATE_STRATEGY: {{ $c.daemonUpdateStrategy | quote }}
   DAEMON_UPDATE_DELAY_MS: {{ $c.daemonUpdateDelayMs | quote }}
   DAEMON_MEMORY_FLOOR_MB: {{ $c.daemonMemoryFloorMb | quote }}
@@ -84,6 +86,9 @@ data:
   TRIAGE_CONFIDENCE_THRESHOLD: {{ $c.triageConfidenceThreshold | quote }}
   TRIAGE_MAX_TOKENS: {{ $c.triageMaxTokens | quote }}
   TRIAGE_TIMEOUT_MS: {{ $c.triageTimeoutMs | quote }}
+  INTENT_CONFIDENCE_THRESHOLD: {{ $c.intentConfidenceThreshold | quote }}
 
   # --- 10. Agent max turns ---
+  {{- if ne ($c.defaultMaxTurns | toString) "" }}
   DEFAULT_MAXTURNS: {{ $c.defaultMaxTurns | quote }}
+  {{- end }}

--- a/charts/github-app-playground/templates/daemon-deployment.yaml
+++ b/charts/github-app-playground/templates/daemon-deployment.yaml
@@ -4,9 +4,9 @@
 {{- $daemonCfg := $.Values.daemon.config }}
 {{- $drainMs := int (ternary $poolCfg.daemonDrainTimeoutMs $daemonCfg.daemonDrainTimeoutMs (hasKey $poolCfg "daemonDrainTimeoutMs")) }}
 {{- $gracePeriod := "" }}
-{{- if ne ($pool.terminationGracePeriodSeconds | toString) "" }}
+{{- if not (empty $pool.terminationGracePeriodSeconds) }}
 {{- $gracePeriod = $pool.terminationGracePeriodSeconds }}
-{{- else if ne ($.Values.daemon.terminationGracePeriodSeconds | toString) "" }}
+{{- else if not (empty $.Values.daemon.terminationGracePeriodSeconds) }}
 {{- $gracePeriod = $.Values.daemon.terminationGracePeriodSeconds }}
 {{- else }}
 {{- $gracePeriod = add (div $drainMs 1000) 30 }}
@@ -159,7 +159,7 @@ spec:
             - name: HEARTBEAT_TIMEOUT_MS
               value: {{ ternary $poolCfg.heartbeatTimeoutMs $daemonCfg.heartbeatTimeoutMs (hasKey $poolCfg "heartbeatTimeoutMs") | quote }}
             - name: STALE_EXECUTION_THRESHOLD_MS
-              value: {{ ternary $poolCfg.staleExecutionThresholdMs $daemonCfg.staleExecutionThresholdMs (hasKey $poolCfg "staleExecutionThresholdMs") | quote }}
+              value: {{ int (ternary $poolCfg.staleExecutionThresholdMs $daemonCfg.staleExecutionThresholdMs (hasKey $poolCfg "staleExecutionThresholdMs")) | quote }}
             - name: DAEMON_DRAIN_TIMEOUT_MS
               value: {{ $drainMs | quote }}
             - name: JOB_MAX_RETRIES

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -384,7 +384,7 @@ daemon:
   config:
     heartbeatIntervalMs: 30000         # HEARTBEAT_INTERVAL_MS
     heartbeatTimeoutMs: 90000          # HEARTBEAT_TIMEOUT_MS (keep >= 2× interval)
-    staleExecutionThresholdMs: 3660000 # STALE_EXECUTION_THRESHOLD_MS; must exceed agentTimeoutMs (3600000)
+    staleExecutionThresholdMs: 3660000  # STALE_EXECUTION_THRESHOLD_MS; must exceed agentTimeoutMs (3600000)
     daemonDrainTimeoutMs: 3600000      # DAEMON_DRAIN_TIMEOUT_MS; must be >= agentTimeoutMs to avoid mid-run kills
     jobMaxRetries: 3                   # JOB_MAX_RETRIES
     offerTimeoutMs: 5000               # OFFER_TIMEOUT_MS

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -314,8 +314,8 @@ config:
   logLevel: info                                # fatal | error | warn | info | debug | trace.
   nodeEnv: production
   maxConcurrentRequests: 3
-  agentTimeoutMs: 600000
-  agentMaxTurns: ""                             # Leave empty to use defaultMaxTurns or triage-derived turns.
+  agentTimeoutMs: 3600000                       # 60min wall-clock cap per agent step. Lower only for testing/smaller-scope deployments; non-trivial implement/review steps routinely run 30-50min.
+  agentMaxTurns: ""                             # Leave empty for no turn cap (recommended). Set to a positive int only when ops needs a hard ceiling; overrides defaultMaxTurns when both are set.
   claudeCodePath: ""                            # Required only when claude-code is installed globally (e.g. Docker).
   allowedOwners: ""                             # Comma-separated. Required when secrets.claudeCodeOauthToken is set.
 
@@ -326,10 +326,12 @@ config:
   orchestratorUrl: ""                           # Setting this flips the process to DAEMON mode (webhook HTTP not started).
   heartbeatIntervalMs: 30000
   heartbeatTimeoutMs: 90000                     # Keep >= 2 x heartbeatIntervalMs.
-  staleExecutionThresholdMs: 660000             # Must exceed agentTimeoutMs (600000).
-  daemonDrainTimeoutMs: 600000                  # Set >= agentTimeoutMs to avoid mid-run kills on SIGTERM.
+  staleExecutionThresholdMs: 3660000            # Must exceed agentTimeoutMs (3600000); 60s margin.
+  daemonDrainTimeoutMs: 3600000                 # Set >= agentTimeoutMs to avoid mid-run kills on SIGTERM. Inflates daemon Pod terminationGracePeriodSeconds (drain/1000 + 30s) — confirm cluster tolerates ~60min graceful shutdown.
   jobMaxRetries: 3
   offerTimeoutMs: 5000
+  queueWorkerBackoffMaxMs: 5000                 # Caps doubling backoff when a leased job has no locally-capable daemon and is re-pushed for another instance to claim.
+  livenessReaperIntervalMs: 30000               # Cadence of the heartbeat-based liveness reaper. Min 20000 (orchestrator heartbeat refresh interval) to avoid false reaps.
   daemonUpdateStrategy: exit                    # exit | pull | notify.
   daemonUpdateDelayMs: 0
   daemonMemoryFloorMb: 512
@@ -350,13 +352,14 @@ config:
 
   # --- 9. Triage (binary heavy classifier) ---
   triageEnabled: true                           # Kill-switch for the triage LLM call.
-  triageModel: haiku-3-5
+  triageModel: haiku-4-5
   triageConfidenceThreshold: 1.0                # Lower to 0.75 only after SC-003/SC-004 stabilise.
   triageMaxTokens: 256
   triageTimeoutMs: 5000
+  intentConfidenceThreshold: 0.75               # Below this, the dispatcher treats the comment as ambiguous and posts a clarification request (FR-009). Matches SC-005 target band.
 
   # --- 10. Agent max turns ---
-  defaultMaxTurns: 30                           # maxTurns is always sourced from this value (triage-derived turns removed).
+  defaultMaxTurns: ""                           # Leave empty for no turn cap (recommended). Set to a positive int only when ops needs a hard ceiling; AGENT_MAX_TURNS overrides this when both are set.
 
 # ─────────────────────────── DAEMON POOLS ─────────────────────────────
 # `daemon:` configures 0..N stateless daemon worker pools. Each pool
@@ -381,8 +384,8 @@ daemon:
   config:
     heartbeatIntervalMs: 30000         # HEARTBEAT_INTERVAL_MS
     heartbeatTimeoutMs: 90000          # HEARTBEAT_TIMEOUT_MS (keep >= 2× interval)
-    staleExecutionThresholdMs: 660000  # STALE_EXECUTION_THRESHOLD_MS; must exceed agentTimeoutMs (600000)
-    daemonDrainTimeoutMs: 600000       # DAEMON_DRAIN_TIMEOUT_MS; must be >= agentTimeoutMs to avoid mid-run kills
+    staleExecutionThresholdMs: 3660000 # STALE_EXECUTION_THRESHOLD_MS; must exceed agentTimeoutMs (3600000)
+    daemonDrainTimeoutMs: 3600000      # DAEMON_DRAIN_TIMEOUT_MS; must be >= agentTimeoutMs to avoid mid-run kills
     jobMaxRetries: 3                   # JOB_MAX_RETRIES
     offerTimeoutMs: 5000               # OFFER_TIMEOUT_MS
     daemonUpdateStrategy: exit         # exit | pull | notify


### PR DESCRIPTION
## Summary

Bumps the `github-app-playground` chart to **0.7.0 / appVersion 1.3.0** to track upstream [v1.3.0](https://github.com/chrisleekr/github-app-playground/releases/tag/v1.3.0).

Three things land together:

1. **New upstream env vars surfaced** as chart-level tunables: `queueWorkerBackoffMaxMs`, `livenessReaperIntervalMs`, `intentConfidenceThreshold`.
2. **Default refresh** to match upstream `src/config.ts`: `agentTimeoutMs` 10min → 60min (with `staleExecutionThresholdMs` and `daemonDrainTimeoutMs` raised in lockstep), `triageModel` `haiku-3-5` → `haiku-4-5`, `defaultMaxTurns` 30 → unset (no cap, upstream guidance).
3. **Bundled fix** for a pre-existing daemon-Pod `terminationGracePeriodSeconds` rendering bug — without it, the new 60min drain default would be silently truncated to K8s default 30s, killing every long-running job mid-flight.

### Why bundle the fix

Go template's `nil | toString` returns the literal string `"<nil>"`, not `""`. The pre-existing guard `ne ($pool.terminationGracePeriodSeconds | toString) ""` therefore always matched when no pool override was set, leaving `$gracePeriod` as nil and the rendered field empty. Daemon Pods inherited K8s default 30s grace — fine when `daemonDrainTimeoutMs` was 600s (still wrong, but symptoms were short SIGKILLs on a few in-flight tasks). With v1.3.0 raising drain to 3600s, every in-flight job would get SIGKILL'd at 30s. Fixing this is in-scope for a bump that depends on the drain default actually taking effect.

```mermaid
flowchart TB
  classDef before fill:#FFE4E1,stroke:#8B0000,color:#000000
  classDef after fill:#E0FFE0,stroke:#006400,color:#000000

  Pre["chart 0.6.1 / appVersion 1.2.2"]:::before
  PreEnv["AGENT_TIMEOUT_MS=600000<br/>STALE_EXECUTION_THRESHOLD_MS=660000<br/>DAEMON_DRAIN_TIMEOUT_MS=600000<br/>TRIAGE_MODEL=haiku-3-5<br/>DEFAULT_MAXTURNS=30"]:::before
  PreBug["daemon Pod terminationGracePeriodSeconds:<br/>renders empty → K8s default 30s<br/>SIGKILL mid-job"]:::before
  PreMissing["No QUEUE_WORKER_BACKOFF_MAX_MS<br/>No LIVENESS_REAPER_INTERVAL_MS<br/>No INTENT_CONFIDENCE_THRESHOLD"]:::before

  Post["chart 0.7.0 / appVersion 1.3.0"]:::after
  PostEnv["AGENT_TIMEOUT_MS=3600000<br/>STALE_EXECUTION_THRESHOLD_MS=3660000<br/>DAEMON_DRAIN_TIMEOUT_MS=3600000<br/>TRIAGE_MODEL=haiku-4-5<br/>DEFAULT_MAXTURNS unset"]:::after
  PostFix["daemon Pod terminationGracePeriodSeconds:<br/>= drain/1000 + 30 = 3630s<br/>graceful drain to completion"]:::after
  PostNew["QUEUE_WORKER_BACKOFF_MAX_MS=5000<br/>LIVENESS_REAPER_INTERVAL_MS=30000<br/>INTENT_CONFIDENCE_THRESHOLD=0.75"]:::after

  Pre --> PreEnv --> PreBug --> PreMissing
  Post --> PostEnv --> PostFix --> PostNew
```

### Operational impact

- Daemon Pods now run with `terminationGracePeriodSeconds ≈ 3630s` (≈ 60.5 min). Confirm node-drain / PDB / spot-termination tooling tolerates long graceful shutdowns. Override via `daemon.terminationGracePeriodSeconds` or per-pool `daemon.pools.<name>.terminationGracePeriodSeconds` to clamp.
- All numeric `_MS` env vars ≥ 1,000,000 now go through `int` in the template to avoid Helm rendering them as scientific notation (`"3.6e+06"`). Functionally equivalent (Zod's `z.coerce.number()` accepts both) but cleaner ConfigMap output.

## Changes

**`Chart.yaml`**
- `version`: 0.6.1 → 0.7.0
- `appVersion`: 1.2.2 → 1.3.0
- `artifacthub.io/changes`: full per-key change list (default bumps + new tunables)

**`values.yaml` — `config:` block**
- `agentTimeoutMs`: 600000 → 3600000
- `staleExecutionThresholdMs`: 660000 → 3660000 (preserves 60s margin over `agentTimeoutMs`)
- `daemonDrainTimeoutMs`: 600000 → 3600000
- `triageModel`: `haiku-3-5` → `haiku-4-5`
- `defaultMaxTurns`: `30` → `""` (unset; upstream switched to optional)
- New: `queueWorkerBackoffMaxMs: 5000` (caps queue-worker re-push backoff)
- New: `livenessReaperIntervalMs: 30000` (heartbeat-reaper cadence; min 20000)
- New: `intentConfidenceThreshold: 0.75` (clarification-vs-dispatch threshold)
- Inline comments updated for `agentTimeoutMs`, `agentMaxTurns`, `daemonDrainTimeoutMs` to reflect new semantics

**`values.yaml` — `daemon.config:` block**
- `staleExecutionThresholdMs`: 660000 → 3660000
- `daemonDrainTimeoutMs`: 600000 → 3600000

**`templates/configmap.yaml`**
- New env vars wired: `QUEUE_WORKER_BACKOFF_MAX_MS`, `LIVENESS_REAPER_INTERVAL_MS`, `INTENT_CONFIDENCE_THRESHOLD`
- `int` cast added to `AGENT_TIMEOUT_MS`, `STALE_EXECUTION_THRESHOLD_MS`, `DAEMON_DRAIN_TIMEOUT_MS` to suppress YAML scientific-notation rendering for ≥ 1M values
- `DEFAULT_MAXTURNS` now gated behind `ne ($c.defaultMaxTurns | toString) ""` (consistent with `AGENT_MAX_TURNS`); empty values are not rendered, letting upstream Zod default apply

**`templates/daemon-deployment.yaml`**
- Pre-existing `terminationGracePeriodSeconds` nil-coercion bug fixed: `ne (... | toString) ""` → `not (empty ...)` (template helper `nil | toString` returns the literal string `"<nil>"`, not empty, which broke the guard)
- `int` cast added to the `STALE_EXECUTION_THRESHOLD_MS` ternary value for the same scientific-notation reason

**`templates/NOTES.txt`**
- New \`Upgrading from chart 0.6.x?\` block at top: lists default changes, drain-bump operational warning, and new env-var defaults
- Previous \`0.5.x → 0.6.0\` BREAKING block kept in place as historical guidance for skip-ahead upgraders

## Test plan

- [x] \`helm lint charts/github-app-playground\` passes
- [x] \`helm template gap charts/github-app-playground\` renders cleanly with default values
- [x] \`helm template gap charts/github-app-playground -f charts/github-app-playground/ci/daemon-pools-values.yaml --set rbac.create=true\` renders cleanly
- [x] Verified rendered ConfigMap values: \`AGENT_TIMEOUT_MS=3600000\`, \`STALE_EXECUTION_THRESHOLD_MS=3660000\`, \`DAEMON_DRAIN_TIMEOUT_MS=3600000\`, \`TRIAGE_MODEL=haiku-4-5\`, \`INTENT_CONFIDENCE_THRESHOLD=0.75\`, \`LIVENESS_REAPER_INTERVAL_MS=30000\`, \`QUEUE_WORKER_BACKOFF_MAX_MS=5000\`
- [x] Verified daemon Pod \`terminationGracePeriodSeconds: 3630\` (was empty pre-fix)
- [x] Verified orchestrator Pod \`terminationGracePeriodSeconds: 300\` (unchanged)
- [x] Verified \`DEFAULT_MAXTURNS\` omitted when empty, rendered when explicitly set
- [x] DockerHub images \`chrisleekr/github-app-playground:1.3.0-orchestrator\` and \`:1.3.0-daemon\` confirmed published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart to v0.7.0 and application to v1.3.0.
  * Increased default timeouts and drain periods for improved stability.
  * Updated triage language model for enhanced performance.

* **New Features**
  * Added queue worker backoff configuration for improved resource management.
  * Added liveness reaper interval control for enhanced monitoring.
  * Added intent confidence threshold to fine-tune triage behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->