### PR TITLE
fix(github-app-playground): bump appVersion to 1.3.1 for OAuth token shadowing fix (v0.7.1)

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.0"
+appVersion: "1.3.1"
 
 kubeVersion: ">= 1.31.0"
 
@@ -46,23 +46,5 @@ sources:
 annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
-    - kind: changed
-      description: "bump appVersion to 1.3.0 (upstream v1.3.0: label-dispatched bot workflow foundation, review handler streams progress, end-to-end runs no longer lose progress to mid-run caps)"
-    - kind: changed
-      description: "config.agentTimeoutMs default 600000 → 3600000 (upstream src/config.ts: 60min wall-clock cap; non-trivial implement/review steps routinely run 30-50min)"
-    - kind: changed
-      description: "config.staleExecutionThresholdMs default 660000 → 3660000 (must stay ≥ agentTimeoutMs; preserves 60s margin)"
-    - kind: changed
-      description: "config.daemonDrainTimeoutMs default 600000 → 3600000 (must stay ≥ agentTimeoutMs to avoid SIGTERM mid-run kills)"
-    - kind: changed
-      description: "daemon.config.staleExecutionThresholdMs and daemon.config.daemonDrainTimeoutMs defaults bumped to match orchestrator"
-    - kind: changed
-      description: "config.triageModel default haiku-3-5 → haiku-4-5 (upstream default refresh)"
-    - kind: changed
-      description: "config.defaultMaxTurns default 30 → \"\" (unset; upstream switched to optional — set only when ops needs a hard ceiling)"
-    - kind: added
-      description: "config.queueWorkerBackoffMaxMs (QUEUE_WORKER_BACKOFF_MAX_MS, default 5000): caps the queue-worker re-push backoff when no local daemon is capable"
-    - kind: added
-      description: "config.livenessReaperIntervalMs (LIVENESS_REAPER_INTERVAL_MS, default 30000, min 20000): cadence of the heartbeat-based liveness reaper that fails workflow_runs whose owner heartbeat is missing"
-    - kind: added
-      description: "config.intentConfidenceThreshold (INTENT_CONFIDENCE_THRESHOLD, default 0.75): minimum classifier confidence before dispatching; below this the bot posts a clarification request instead"
+    - kind: fixed
+      description: "bump appVersion to 1.3.1 (upstream PR #59 prevents an empty ANTHROPIC_API_KEY env var from shadowing the real Claude Code OAuth token, restoring auth when secrets.claudeCodeOauthToken is set without secrets.anthropicApiKey)"

--- a/charts/github-app-playground/templates/NOTES.txt
+++ b/charts/github-app-playground/templates/NOTES.txt
@@ -1,4 +1,4 @@
-Upgrading from chart 0.6.x? (chart 0.7.0 / appVersion 1.3.0)
+Upgrading from chart 0.6.x? (chart 0.7.0+ / appVersion 1.3.1)
   Upstream v1.3.0 ships label-dispatched bot workflows, review-handler
   progress streaming, and end-to-end runs that no longer lose progress to
   mid-run turn caps. The chart bumps defaults to match upstream and exposes


### PR DESCRIPTION
## Summary

- Bumps `github-app-playground` chart `appVersion` `1.3.0` → `1.3.1` and chart `version` `0.7.0` → `0.7.1` for the upstream patch release [v1.3.1](https://github.com/chrisleekr/github-app-playground/releases/tag/v1.3.1).
- Upstream PR [#59](https://github.com/chrisleekr/github-app-playground/pull/59) prevents an empty `ANTHROPIC_API_KEY` env var from shadowing the real Claude Code OAuth token. Restores authentication for deployments that set `secrets.claudeCodeOauthToken` without also setting `secrets.anthropicApiKey`.
- No `values.yaml` or template behaviour changes — `helm upgrade` is a transparent rollout.
- Replaces the `artifacthub.io/changes` annotation with the single `fixed` entry for this release, and updates the NOTES.txt header to reflect the new chart/app versions.

## Test plan

- [ ] `ct lint --charts charts/github-app-playground` passes in CI
- [ ] `helm template` renders cleanly with default values and with `secrets.claudeCodeOauthToken` set / `secrets.anthropicApiKey` empty
- [ ] Confirm chart-releaser publishes `github-app-playground-0.7.1` after merge

https://claude.ai/code/session_013ibo66Zxex4ehuvxVwvEHg

---
_Generated by [Claude Code](https://claude.ai/code/session_013ibo66Zxex4ehuvxVwvEHg)_