### PR TITLE
fix(github-app-playground): bump appVersion to 1.3.2 for triage summary truncation fix (v0.7.2)

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.1
+version: 0.7.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.1"
+appVersion: "1.3.2"
 
 kubeVersion: ">= 1.31.0"
 
@@ -47,4 +47,4 @@ annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
     - kind: fixed
-      description: "bump appVersion to 1.3.1 (upstream PR #59 prevents an empty ANTHROPIC_API_KEY env var from shadowing the real Claude Code OAuth token, restoring auth when secrets.claudeCodeOauthToken is set without secrets.anthropicApiKey)"
+      description: "bump appVersion to 1.3.2 (upstream PR #60 removes the 500-char cap on triage verdict summaries, so long classifier explanations are no longer truncated in PR comments / logs)"

--- a/charts/github-app-playground/templates/NOTES.txt
+++ b/charts/github-app-playground/templates/NOTES.txt
@@ -1,4 +1,4 @@
-Upgrading from chart 0.6.x? (chart 0.7.0+ / appVersion 1.3.1)
+Upgrading from chart 0.6.x? (chart 0.7.0+ / appVersion 1.3.2)
   Upstream v1.3.0 ships label-dispatched bot workflows, review-handler
   progress streaming, and end-to-end runs that no longer lose progress to
   mid-run turn caps. The chart bumps defaults to match upstream and exposes


### PR DESCRIPTION
## Summary

- Bumps `github-app-playground` chart `appVersion` `1.3.1` → `1.3.2` and chart `version` `0.7.1` → `0.7.2` for the upstream patch release [v1.3.2](https://github.com/chrisleekr/github-app-playground/releases/tag/v1.3.2).
- Upstream PR [#60](https://github.com/chrisleekr/github-app-playground/pull/60) removes the 500-char cap on triage verdict summaries, so long classifier explanations are no longer truncated in PR comments / logs.
- No `values.yaml` or template behaviour changes — `helm upgrade` is a transparent rollout.
- Replaces the `artifacthub.io/changes` annotation with the single `fixed` entry for this release, and updates the NOTES.txt header to reflect the new appVersion.

## Test plan

- [ ] `ct lint --charts charts/github-app-playground` passes in CI
- [ ] `helm template` renders cleanly with default values
- [ ] Confirm chart-releaser publishes `github-app-playground-0.7.2` after merge

https://claude.ai/code/session_013ibo66Zxex4ehuvxVwvEHg

---
_Generated by [Claude Code](https://claude.ai/code/session_013ibo66Zxex4ehuvxVwvEHg)_