### PR TITLE
feat(github-app-playground): bump chart to v0.8.0 / appVersion 1.4.0

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.2
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.2"
+appVersion: "1.4.0"
 
 kubeVersion: ">= 1.31.0"
 
@@ -46,5 +46,5 @@ sources:
 annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "bump appVersion to 1.3.2 (upstream PR #60 removes the 500-char cap on triage verdict summaries, so long classifier explanations are no longer truncated in PR comments / logs)"
+    - kind: added
+      description: "bump appVersion to 1.4.0 (upstream PR #61 adds up-front workflow tracking comments, 4-stage trigger reactions 👀/🚀/🎉/😕, parent composite cascade, and daemon-disconnect recovery comments — closes the silent multi-minute UX gap during triage/plan/implement and the OOM silent-failure window). Includes auto-applied DB migration 007_trigger_comment.sql adding nullable trigger_comment_id/trigger_event_type columns to workflow_runs and executions."


### PR DESCRIPTION
## Summary

Bumps the `github-app-playground` chart to **v0.8.0** and pins `appVersion` to **1.4.0**, picking up upstream [release v1.4.0](https://github.com/chrisleekr/github-app-playground/releases/tag/v1.4.0) (PR [chrisleekr/github-app-playground#61](https://github.com/chrisleekr/github-app-playground/pull/61)).

The upstream release closes two long-standing UX gaps in the bot workflow lifecycle:

1. **Silent multi-minute window** during `triage` / `plan` / `implement` runs — users previously saw nothing until the agent finished (sometimes 10+ minutes later).
2. **Silent failure window** when the daemon dies mid-job (e.g. OOM kill from issue #16) — the workflow chain just stopped with no user-facing signal.

It introduces three coordinated user-facing surfaces — up-front tracking comments, 4-stage GitHub reactions on the trigger comment (👀 → 🚀 → 🎉/😕), and a verbose composite parent body that cascades child step status — plus a `cleanupAfterDisconnect` flow that walks orphaned `workflow_runs`, finds the topmost ancestor, and posts a recoverable-failure message to the comment the user is actually watching.

### Why this is a chart-level no-op beyond the image pin

I diffed `v1.3.2...v1.4.0` upstream. The release touches only application code, one new SQL migration, and tests:

- **No** changes to `.env.example`
- **No** changes to `src/config.ts`
- **No** new env vars, CLI flags, or runtime configuration knobs
- **No** Dockerfile or image-shape changes
- **New** `src/db/migrations/007_trigger_comment.sql` — auto-applied on daemon startup; adds two `NULL`-able columns (`trigger_comment_id BIGINT`, `trigger_event_type TEXT` with a `CHECK` constraint) to `workflow_runs` and `executions`. Pre-existing rows are intentionally not backfilled — the reaction lifecycle only matters for jobs dispatched after this migration.

Therefore this PR touches **only `Chart.yaml`** — version, appVersion, and the `artifacthub.io/changes` annotation. No `values.yaml`, ConfigMap, or Deployment changes are needed.

### Before

```mermaid
flowchart LR
    Chart["helm-charts<br/>chart 0.7.2<br/>appVersion 1.3.2"]:::current
    Image["github-app-playground<br/>v1.3.2 image"]:::image
    User["User comments<br/>@chrisleekr-bot ship"]:::user
    Silent["Silent ~10min run<br/>no comments<br/>no reactions"]:::silent
    OOMSilent["OOM kill →<br/>no user-facing signal"]:::fail

    Chart --> Image --> User --> Silent --> OOMSilent

    classDef current fill:#1e3a8a,stroke:#bfdbfe,color:#ffffff
    classDef image fill:#374151,stroke:#d1d5db,color:#ffffff
    classDef user fill:#1e3a8a,stroke:#bfdbfe,color:#ffffff
    classDef silent fill:#7f1d1d,stroke:#fecaca,color:#ffffff
    classDef fail fill:#7f1d1d,stroke:#fecaca,color:#ffffff
```

### After

```mermaid
flowchart LR
    Chart["helm-charts<br/>chart 0.8.0<br/>appVersion 1.4.0"]:::new
    Image["github-app-playground<br/>v1.4.0 image"]:::image
    Migration["007_trigger_comment.sql<br/>auto-applied on startup"]:::migrate
    User["User comments<br/>@chrisleekr-bot ship"]:::user
    Reactions["👀 → 🚀 → 🎉/😕<br/>on trigger comment"]:::ok
    Tracking["Up-front tracking comment<br/>per workflow + composite cascade"]:::ok
    OOMRecover["Daemon disconnect →<br/>ancestor comment updated<br/>+ 😕 reaction"]:::warn

    Chart --> Image --> Migration --> User --> Reactions --> Tracking --> OOMRecover

    classDef new fill:#065f46,stroke:#a7f3d0,color:#ffffff
    classDef image fill:#374151,stroke:#d1d5db,color:#ffffff
    classDef migrate fill:#0f766e,stroke:#99f6e4,color:#ffffff
    classDef user fill:#1e3a8a,stroke:#bfdbfe,color:#ffffff
    classDef ok fill:#065f46,stroke:#a7f3d0,color:#ffffff
    classDef warn fill:#92400e,stroke:#fde68a,color:#ffffff
```

## Changes

- `charts/github-app-playground/Chart.yaml`
  - `version`: `0.7.2` → `0.8.0` (minor bump — matches the precedent set when v1.3.0 shipped as chart `0.7.0`; consistent with semver since the upstream release is itself a minor version with new user-visible features)
  - `appVersion`: `"1.3.2"` → `"1.4.0"` (pin to the new image)
  - `artifacthub.io/changes`: replaced the prior `kind: fixed` v1.3.2 entry with a `kind: added` v1.4.0 entry summarising the new tracking-comment / reaction / disconnect-recovery surfaces and noting the auto-applied DB migration

## Upgrade impact for chart consumers

- **No values changes required.** `helm upgrade` with the existing `values.yaml` will roll forward cleanly.
- **No restart-related operator action.** The new SQL migration applies automatically when the daemon pod starts; rollout is the standard Deployment update path.
- **No breaking changes.** All reaction / tracking-comment behaviour is additive on the GitHub side; existing `workflow_runs` rows remain valid (new columns are nullable).
- **First job dispatched post-upgrade** is the first one to get the new reaction lifecycle — pre-existing in-flight rows from before the upgrade will not be retroactively annotated.

## Verification

- [x] `helm lint charts/github-app-playground` — `1 chart(s) linted, 0 chart(s) failed` (only the pre-existing `[INFO] icon is recommended` notice)
- [x] Diff scoped to a single file (`Chart.yaml`, +4 / -4)
- [x] Confirmed against upstream `v1.3.2...v1.4.0` compare that no `.env.example` / `src/config.ts` / Dockerfile changes exist
- [ ] CI lint workflow on this PR (will run on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)