### PR TITLE
fix(github-app-playground): pin postgres VCT labels to selectorLabels (v0.8.1)

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -46,5 +46,5 @@ sources:
 annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
-    - kind: added
-      description: "bump appVersion to 1.4.0 (upstream PR #61 adds up-front workflow tracking comments, 4-stage trigger reactions 👀/🚀/🎉/😕, parent composite cascade, and daemon-disconnect recovery comments — closes the silent multi-minute UX gap during triage/plan/implement and the OOM silent-failure window). Includes auto-applied DB migration 007_trigger_comment.sql adding nullable trigger_comment_id/trigger_event_type columns to workflow_runs and executions."
+    - kind: fixed
+      description: "postgres StatefulSet volumeClaimTemplates labels now use the stable selectorLabels subset (name + instance) plus constant managed-by, instead of the full labels helper. The full helper injected helm.sh/chart and app.kubernetes.io/version, which change every chart bump. Because spec.volumeClaimTemplates is immutable in Kubernetes, those volatile labels created a permanent ArgoCD OutOfSync diff that could not be reconciled without orphan-deleting the PVC. NOTE: existing live StatefulSets still carry the stale labels — one orphan-delete + re-sync is needed after upgrading to clear the drift; subsequent chart bumps will be clean."

--- a/charts/github-app-playground/templates/postgres-statefulset.yaml
+++ b/charts/github-app-playground/templates/postgres-statefulset.yaml
@@ -108,8 +108,14 @@ spec:
     - metadata:
         name: data
         labels:
-          {{- include "github-app-playground.labels" . | nindent 10 }}
+          {{- /* StatefulSet volumeClaimTemplates is immutable per the Kubernetes API. The full
+                "labels" helper injects helm.sh/chart and app.kubernetes.io/version, both of which
+                change on every chart bump and would create a permanent ArgoCD OutOfSync diff that
+                cannot be reconciled without orphan-deleting the PVC. Pin to selectorLabels (stable
+                name + instance) plus constant extras only. */}}
+          {{- include "github-app-playground.selectorLabels" . | nindent 10 }}
           app.kubernetes.io/component: postgres
+          app.kubernetes.io/managed-by: {{ .Release.Service }}
       spec:
         accessModes:
           {{- range .Values.postgres.persistence.accessModes }}


### PR DESCRIPTION
## Summary

Patch bump **chart `github-app-playground` 0.8.0 → 0.8.1** (appVersion unchanged at `1.4.0`).

Fixes a permanent ArgoCD `OutOfSync` diff on the postgres `StatefulSet` caused by volatile labels embedded in the immutable `volumeClaimTemplates`.

## Root cause

`templates/postgres-statefulset.yaml` rendered VCT labels via the full `github-app-playground.labels` helper:

```yaml
volumeClaimTemplates:
  - metadata:
      labels:
        {{- include "github-app-playground.labels" . | nindent 10 }}   # ← injects 5 labels
        app.kubernetes.io/component: postgres
```

That helper expands into:

| Label | Stable? |
| --- | --- |
| `app.kubernetes.io/name` | ✅ stable (Chart.Name) |
| `app.kubernetes.io/instance` | ✅ stable (Release.Name) |
| `app.kubernetes.io/managed-by` | ✅ stable (`Helm`) |
| `helm.sh/chart` | ❌ changes every chart bump (e.g. `...-0.8.0` → `...-0.8.1`) |
| `app.kubernetes.io/version` | ❌ changes every appVersion bump |

`spec.volumeClaimTemplates` is **immutable** per the [Kubernetes API ref](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds) — the apiserver rejects attempts to patch most fields, including labels under a stored VCT. Result: every chart/appVersion bump leaves a permanent diff that ArgoCD can't reconcile without orphan-deleting the PVC and re-syncing.

Other resources (`Deployment`, `Service`, etc.) tolerate the volatile labels because they're mutable — the labels just rotate cleanly on each release.

## Fix

Pin VCT labels to the stable `selectorLabels` subset (`name` + `instance`) plus constant extras:

```yaml
volumeClaimTemplates:
  - metadata:
      labels:
        {{- include "github-app-playground.selectorLabels" . | nindent 10 }}
        app.kubernetes.io/component: postgres
        app.kubernetes.io/managed-by: {{ .Release.Service }}
```

A multi-line WHY comment is added in-place so a future maintainer doesn't undo this — per Helm best-practice docs ([labels and annotations](https://helm.sh/docs/chart_best_practices/labels/)) and Bitnami's `common.labels.matchLabels` precedent, immutable selectors / specs use only the stable subset.

## Verification

- `helm lint` — passes
- Rendered VCT now contains only: `name`, `instance`, `component`, `managed-by`. No `helm.sh/chart`, no `app.kubernetes.io/version`.
- Diff between `helm template` at current chart version vs. simulated `0.9.0` + `appVersion=99.99.99` — **byte-identical** VCT block.

## ⚠️ One-time migration required after deploy

Existing live `StatefulSet`s still carry the stale immutable labels burned in. After this chart ships, the first ArgoCD sync will **still** show OutOfSync until you orphan-delete the StatefulSet (preserving the PVC) and re-sync once. Subsequent bumps will be clean.

```bash
kubectl delete statefulset <release>-github-app-playground-postgres -n <ns> --cascade=orphan
# then ArgoCD sync — VCT is recreated with the new stable labels; PVC reattaches.
```

## Out of scope

Separate ArgoCD diff on `apiVersion: v1` / `kind: PersistentVolumeClaim` lines (server-side defaulting on stored VCTs vs. Helm-rendered VCTs that omit them) — mitigated by enabling [ArgoCD `ServerSideDiff=true`](https://argo-cd.readthedocs.io/en/stable/user-guide/diffing/#server-side-diff). Not addressed here.

## Test plan

- [ ] CI: `lint.yml` passes (helm lint + yamllint).
- [ ] Render `helm template` with `postgres.enabled=true` — confirm VCT labels do **not** include `helm.sh/chart` or `app.kubernetes.io/version`.
- [ ] (Post-merge, in cluster) After upgrading to `0.8.1`, perform one orphan-delete of the postgres StatefulSet, re-sync, confirm ArgoCD reaches `Synced` and stays there on subsequent chart bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PostgreSQL StatefulSet labeling causing unreconcilable ArgoCD sync differences
  * Stabilized volume claim template labels across chart revisions to prevent Kubernetes immutability issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->