### PR TITLE
feat(github-app-playground): bump chart to v0.9.0 / appVersion 1.5.0

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.4.0"
+appVersion: "1.5.0"
 
 kubeVersion: ">= 1.31.0"
 
@@ -46,5 +46,7 @@ sources:
 annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "postgres StatefulSet volumeClaimTemplates labels now use the stable selectorLabels subset (name + instance) plus constant managed-by, instead of the full labels helper. The full helper injected helm.sh/chart and app.kubernetes.io/version, which change every chart bump. Because spec.volumeClaimTemplates is immutable in Kubernetes, those volatile labels created a permanent ArgoCD OutOfSync diff that could not be reconciled without orphan-deleting the PVC. NOTE: existing live StatefulSets still carry the stale labels — one orphan-delete + re-sync is needed after upgrading to clear the drift; subsequent chart bumps will be clean."
+    - kind: changed
+      description: "Bumped appVersion to 1.5.0. Upstream adds cascade PR retargeting in the ship pipeline (review/resolve now run against the PR opened by implement instead of the original issue) and a bounded review→resolve loop that stops cleanly when findings reach zero, with a manual-re-review hint if the cap is hit."
+    - kind: added
+      description: "New optional tunable config.reviewResolveMaxIterations (env REVIEW_RESOLVE_MAX_ITERATIONS, int 1–5, upstream default 2). Caps how many review→resolve passes the composite ship workflow runs before terminating. Empty string in values.yaml leaves the upstream default in effect."

--- a/charts/github-app-playground/templates/configmap.yaml
+++ b/charts/github-app-playground/templates/configmap.yaml
@@ -92,3 +92,8 @@ data:
   {{- if ne ($c.defaultMaxTurns | toString) "" }}
   DEFAULT_MAXTURNS: {{ $c.defaultMaxTurns | quote }}
   {{- end }}
+
+  # --- 12. Composite ship review/resolve loop ---
+  {{- if ne ($c.reviewResolveMaxIterations | toString) "" }}
+  REVIEW_RESOLVE_MAX_ITERATIONS: {{ int $c.reviewResolveMaxIterations | quote }}
+  {{- end }}

--- a/charts/github-app-playground/templates/configmap.yaml
+++ b/charts/github-app-playground/templates/configmap.yaml
@@ -95,5 +95,5 @@ data:
 
   # --- 12. Composite ship review/resolve loop ---
   {{- if ne ($c.reviewResolveMaxIterations | toString) "" }}
-  REVIEW_RESOLVE_MAX_ITERATIONS: {{ int $c.reviewResolveMaxIterations | quote }}
+  REVIEW_RESOLVE_MAX_ITERATIONS: {{ $c.reviewResolveMaxIterations | quote }}
   {{- end }}

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -361,6 +361,9 @@ config:
   # --- 10. Agent max turns ---
   defaultMaxTurns: ""                           # Leave empty for no turn cap (recommended). Set to a positive int only when ops needs a hard ceiling; AGENT_MAX_TURNS overrides this when both are set.
 
+  # --- 12. Composite ship review/resolve loop ---
+  reviewResolveMaxIterations: ""                # Leave empty to use the upstream default (2). Range: 1–5. Caps how many review→resolve passes the ship pipeline runs before terminating with a manual-re-review hint when findings remain.
+
 # ─────────────────────────── DAEMON POOLS ─────────────────────────────
 # `daemon:` configures 0..N stateless daemon worker pools. Each pool
 # renders its own Deployment. Daemons connect outbound to the orchestrator


### PR DESCRIPTION
## Summary

Bumps `github-app-playground` Helm chart to **v0.9.0** with **appVersion 1.5.0** (chrisleekr/github-app-playground#63 — cascade PR retargeting + bounded review/resolve loop).

Upstream v1.5.0 fixes the ship pipeline cascade: `review` and `resolve` were inheriting the parent ship's **issue** target and bailing immediately because they require a PR target. v1.5.0 retargets cascade children to the PR opened by `implement`, and runs a bounded review→resolve loop that exits cleanly when findings reach zero (or hits the cap and emits a manual-re-review hint).

This chart bump exposes the one new tunable upstream introduced — `REVIEW_RESOLVE_MAX_ITERATIONS` (int, range 1–5, upstream default 2) — as `config.reviewResolveMaxIterations` in `values.yaml`. It is gated by the same `ne … ""` non-empty check used by the sibling cap tunables (`AGENT_MAX_TURNS`, `DEFAULT_MAXTURNS`), so leaving it empty omits the env var entirely and the upstream Zod default takes effect.

Chart **minor** bump (`0.8.1 → 0.9.0`) is appropriate because we are adding a new, optional, backward-compatible values knob — not just an appVersion bump.

### Before

```mermaid
flowchart LR
  values["values.yaml<br/>config.*"]:::cur
  cm["templates/configmap.yaml<br/>Groups 1–10"]:::cur
  pod["pod env"]:::cur
  zod["upstream Zod schema<br/>reviewResolveMaxIterations<br/>default 2 — unreachable"]:::miss

  values --> cm --> pod --> zod

  classDef cur fill:#1f3a5f,color:#ffffff,stroke:#ffffff
  classDef miss fill:#922b21,color:#ffffff,stroke:#ffffff
```

### After

```mermaid
flowchart LR
  values["values.yaml<br/>config.reviewResolveMaxIterations<br/>empty by default"]:::add
  gate{"value != empty?"}:::add
  emit["REVIEW_RESOLVE_MAX_ITERATIONS<br/>quoted"]:::add
  skip["env var not emitted"]:::cur
  pod["pod env"]:::cur
  zod["upstream Zod<br/>z.coerce.number.int<br/>1–5, default 2"]:::cur

  values --> gate
  gate -- "yes" --> emit --> pod --> zod
  gate -- "no" --> skip --> pod --> zod

  classDef cur fill:#1f3a5f,color:#ffffff,stroke:#ffffff
  classDef add fill:#196f3d,color:#ffffff,stroke:#ffffff
```

## Changes

- **`Chart.yaml`** — chart `0.8.1 → 0.9.0`, `appVersion "1.4.0" → "1.5.0"`. Replaced previous `artifacthub.io/changes` entry with two new entries: a `changed` entry describing the upstream behaviour change, and an `added` entry describing the new tunable.
- **`values.yaml`** — added Group 12 section with `reviewResolveMaxIterations: ""` (empty default = use upstream default of 2). Range and behaviour documented inline.
- **`templates/configmap.yaml`** — added Group 12 section emitting `REVIEW_RESOLVE_MAX_ITERATIONS` only when the value is non-empty, matching the gate-and-quote pattern of sibling cap tunables `AGENT_MAX_TURNS` (line 41) and `DEFAULT_MAXTURNS` (line 93). No `int` cast — upstream Zod uses `z.coerce.number().int()` which already handles the string→int coercion.

## Verification

- `helm lint charts/github-app-playground` — clean (1 INFO about `icon`, pre-existing).
- `helm template charts/github-app-playground` (default values) — `REVIEW_RESOLVE_MAX_ITERATIONS` **not present** in rendered ConfigMap (upstream Zod default of 2 takes effect).
- `helm template charts/github-app-playground --set config.reviewResolveMaxIterations=4` — renders `REVIEW_RESOLVE_MAX_ITERATIONS: "4"` (quoted string, as required by ConfigMap).
