### PR TITLE
feat(github-app-playground): bump chart to v0.10.0 / appVersion 1.6.0

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.5.0"
+appVersion: "1.6.0"
 
 kubeVersion: ">= 1.31.0"
 
@@ -47,6 +47,6 @@ annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
     - kind: changed
-      description: "Bumped appVersion to 1.5.0. Upstream adds cascade PR retargeting in the ship pipeline (review/resolve now run against the PR opened by implement instead of the original issue) and a bounded review→resolve loop that stops cleanly when findings reach zero, with a manual-re-review hint if the cap is hit."
-    - kind: added
-      description: "New optional tunable config.reviewResolveMaxIterations (env REVIEW_RESOLVE_MAX_ITERATIONS, int 1–5, upstream default 2). Caps how many review→resolve passes the composite ship workflow runs before terminating. Empty string in values.yaml leaves the upstream default in effect."
+      description: "Bumped appVersion to 1.6.0. Upstream tightens the triage agent's bug reproduction methodology prompt for more reliable repro steps."
+    - kind: fixed
+      description: "Upstream pipeline now aborts the in-flight Claude Agent SDK query when a job times out or the daemon cancels it, preventing orphaned queries from continuing after cancellation."


### PR DESCRIPTION
## Summary

Bump the `github-app-playground` Helm chart to consume upstream [`chrisleekr/github-app-playground` v1.6.0](https://github.com/chrisleekr/github-app-playground/releases/tag/v1.6.0).

- `version`: `0.9.0` → `0.10.0` (minor — matches upstream minor release, consistent with the `v0.8.0`→`v0.9.0` (`1.4.0`→`1.5.0`) precedent)
- `appVersion`: `1.5.0` → `1.6.0`
- Refreshed `artifacthub.io/changes` annotation

## Upstream changes consumed (v1.5.0..v1.6.0)

- **fix(pipeline)** — abort the in-flight Claude Agent SDK query on job timeout / daemon cancel ([#62](https://github.com/chrisleekr/github-app-playground/pull/62)). Prevents orphaned SDK queries continuing after cancellation.
- **feat(triage)** — tighten bug reproduction methodology in the triage agent prompt ([#64](https://github.com/chrisleekr/github-app-playground/pull/64)) for more reliable repro steps.

## Chart impact

**Chart.yaml only.** No `values.yaml`, ConfigMap, or template changes — the upstream diff (`v1.5.0..v1.6.0`) touches only `src/**`, tests, and docs. No new env vars, no removed env vars, no schema changes. Existing deployments require no values updates.

## Verification

- [x] `helm lint charts/github-app-playground` → `1 chart(s) linted, 0 chart(s) failed`
- [x] Upstream changed-files audit (`gh api .../compare/v1.5.0...v1.6.0`) → no config/env/values surface area touched
- [x] Diff review: only `Chart.yaml` modified, 5 insertions / 5 deletions

## Test plan

- [ ] CI lint workflow passes on the PR
- [ ] CodeRabbit review (no actionable findings expected — appVersion-only bump)
- [ ] Optional: render a release artifact via `helm package charts/github-app-playground` post-merge to confirm the `0.10.0` tarball builds clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved bug reproduction guidance in documentation

* **Bug Fixes**
  * Fixed pipeline behavior to properly abort in-flight queries when jobs timeout or are canceled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->