### PR TITLE
fix(github-app-playground): bump chart to v0.10.1 / appVersion 1.6.1

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.10.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.6.0"
+appVersion: "1.6.1"
 
 kubeVersion: ">= 1.31.0"
 
@@ -46,7 +46,5 @@ sources:
 annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Bumped appVersion to 1.6.0. Upstream tightens the triage agent's bug reproduction methodology prompt for more reliable repro steps."
     - kind: fixed
-      description: "Upstream pipeline now aborts the in-flight Claude Agent SDK query when a job times out or the daemon cancels it, preventing orphaned queries from continuing after cancellation."
+      description: "Bumped appVersion to 1.6.1. Upstream raises the triage verdict details cap to a 50k sanity bound, preventing premature truncation of detailed verdict output."


### PR DESCRIPTION
## Summary

Bump the `github-app-playground` Helm chart to consume upstream [`chrisleekr/github-app-playground` v1.6.1](https://github.com/chrisleekr/github-app-playground/releases/tag/v1.6.1) — a single-fix patch release.

- `version`: `0.10.0` → `0.10.1` (patch — matches upstream patch release)
- `appVersion`: `1.6.0` → `1.6.1`
- Refreshed `artifacthub.io/changes` annotation with the v1.6.1 fix entry

```mermaid
flowchart LR
  classDef before fill:#fde68a,stroke:#92400e,color:#1f2937
  classDef after  fill:#bbf7d0,stroke:#065f46,color:#064e3b
  classDef stable fill:#e5e7eb,stroke:#374151,color:#111827

  Chart010["Chart.yaml<br/>version 0.10.0<br/>appVersion 1.6.0"]:::before
  App160["upstream v1.6.0<br/>verdict details capped early"]:::before
  Values["values.yaml / ConfigMap<br/>unchanged"]:::stable

  Chart011["Chart.yaml<br/>version 0.10.1<br/>appVersion 1.6.1"]:::after
  App161["upstream v1.6.1<br/>verdict details cap raised to 50k"]:::after

  Chart010 --> Chart011
  App160 --> App161
  Values --> Values
```

## Upstream changes consumed (v1.6.0..v1.6.1)

- **fix(triage)** — raise verdict details cap to a 50k sanity bound ([#67](https://github.com/chrisleekr/github-app-playground/pull/67), commit [`4634ff7`](https://github.com/chrisleekr/github-app-playground/commit/4634ff7cc8f0dd8c92541500781b706b2c6d2d80)). Prevents premature truncation of detailed triage verdict output.

## Chart impact

**Chart.yaml only.** Upstream diff (`v1.6.0..v1.6.1`) touches only `src/workflows/handlers/triage.ts`, `package.json`, `CHANGELOG.md`, and `docs/BOT-WORKFLOWS.md` — no `values.yaml`, ConfigMap, or template surface area. No new/removed env vars, no schema changes. Existing deployments require no values updates.

## Verification

- [x] `helm lint charts/github-app-playground` → `1 chart(s) linted, 0 chart(s) failed`
- [x] Upstream changed-files audit (`gh api .../compare/v1.6.0...v1.6.1`) → no config/env/values surface area touched
- [x] Diff review: only `Chart.yaml` modified

## Test plan

- [ ] CI lint workflow passes on the PR
- [ ] CodeRabbit review (no actionable findings expected — appVersion-only patch bump)
- [ ] Optional: `helm package charts/github-app-playground` post-merge confirms the `0.10.1` tarball builds clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved triage verdict details handling by increasing the processing limit to 50,000 entries, enhancing support for larger datasets.

* **Chores**
  * Helm chart version bumped to 0.10.1.
  * Application version bumped to 1.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->