### PR TITLE
fix(github-app-playground): bump chart to v0.11.1 / appVersion 1.8.0

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -23,7 +23,7 @@ version: 0.11.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.7.0"
+appVersion: "1.8.0"
 
 kubeVersion: ">= 1.31.0"
 
@@ -47,6 +47,12 @@ annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
     - kind: added
-      description: "Bumped appVersion to 1.7.0. Adds the upstream PR-shepherding (`bot:ship`) workflow: scoped commands, iteration loop, tickle scheduler, and four scoped executors. Exposes 8 new optional config keys mirroring src/config.ts: `botAppLogin` (group 5) and group 13 ship-loop tunables (`maxWallClockPerShipRun`, `maxShipIterations`, `cronTickleIntervalMs`, `mergeableNullBackoffMsList`, `reviewBarrierSafetyMarginMs`, `fixAttemptsPerSignatureCap`, `shipForbiddenTargetBranches`)."
+      description: "Bumped appVersion to 1.8.0 (covers upstream v1.7.0 + v1.8.0). Adds the upstream PR-shepherding (`bot:ship`) workflow: scoped commands, iteration loop, tickle scheduler, and four scoped executors. Exposes 8 new optional config keys mirroring src/config.ts: `botAppLogin` (group 5) and group 13 ship-loop tunables (`maxWallClockPerShipRun`, `maxShipIterations`, `cronTickleIntervalMs`, `mergeableNullBackoffMsList`, `reviewBarrierSafetyMarginMs`, `fixAttemptsPerSignatureCap`, `shipForbiddenTargetBranches`)."
+    - kind: changed
+      description: "Bot reply format unified across workflows; research/resolve guards hardened (upstream #91)."
+    - kind: fixed
+      description: "Logger now redacts file paths and scrubs `err.*` before pino emits (upstream #89)."
+    - kind: fixed
+      description: "Raw error messages are redacted before being posted in public PR comments (upstream #90)."
     - kind: fixed
       description: "Idempotency: durable check is now scoped with `since=triggerTimestamp` (upstream #69)."

--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.0
+version: 0.11.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
## Summary

Bumps the `github-app-playground` Helm chart to **v0.11.1** and `appVersion` to **v1.8.0** ([upstream release](https://github.com/chrisleekr/github-app-playground/releases/tag/v1.8.0)).

This is a **code-only upstream release** — no `.env.example` or `src/config.ts` changes between v1.7.0 and v1.8.0. Chart `version` is bumped patch (`0.11.0 → 0.11.1`) because the only delta is `appVersion` + changelog; no chart-side surface change. (CI's `chart-testing` requires every chart-modifying PR to bump `version`.)

```mermaid
flowchart LR
    Old["Chart 0.11.0<br/>appVersion 1.7.0"]:::before
    Arrow["appVersion + patch bump<br/>no values/configmap deltas"]:::change
    New["Chart 0.11.1<br/>appVersion 1.8.0"]:::after
    Old --> Arrow --> New
    classDef before fill:#fff4e5,stroke:#cc6600,color:#1a1a1a
    classDef change fill:#e0e7ff,stroke:#3730a3,color:#1a1a1a
    classDef after  fill:#d1fae5,stroke:#065f46,color:#1a1a1a
```

## Changes

### Chart metadata
- `Chart.yaml`: `version 0.11.0 → 0.11.1` (patch — no chart-surface change), `appVersion "1.7.0" → "1.8.0"`
- `artifacthub.io/changes`: appended three new entries reflecting upstream v1.8.0 (one `changed` for unified bot-reply format, two `fixed` for logger/security redaction)

### Upstream v1.8.0 contents (informational)
- **fix(logger):** redact paths and scrub `err.*` before pino emits ([upstream #89](https://github.com/chrisleekr/github-app-playground/pull/89), closes upstream #52)
- **fix(security):** redact raw error messages from public PR comments ([upstream #90](https://github.com/chrisleekr/github-app-playground/pull/90))
- **feat(workflows):** unify bot reply format and harden research/resolve guards ([upstream #91](https://github.com/chrisleekr/github-app-playground/pull/91))

### Verification
- `helm lint` — clean
- `helm template` — `app.kubernetes.io/version: "1.8.0"` and `helm.sh/chart: github-app-playground-0.11.1` rendered on all manifests

### Notes
- No new env vars, secrets, RBAC, volumes, or service-port changes
- No new database migrations
- Existing deployments upgrade by image-tag only — no chart-value changes required
