### PR TITLE
feat(github-app-playground): bump chart to v0.12.0 / appVersion 1.9.1

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.1
+version: 0.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.8.0"
+appVersion: "1.9.1"
 
 kubeVersion: ">= 1.31.0"
 

--- a/charts/github-app-playground/templates/configmap.yaml
+++ b/charts/github-app-playground/templates/configmap.yaml
@@ -37,6 +37,10 @@ data:
   LOG_LEVEL: {{ $c.logLevel | quote }}
   NODE_ENV: {{ $c.nodeEnv | quote }}
   MAX_CONCURRENT_REQUESTS: {{ $c.maxConcurrentRequests | quote }}
+  MAX_FETCHED_COMMENTS: {{ $c.maxFetchedComments | quote }}
+  MAX_FETCHED_REVIEWS: {{ $c.maxFetchedReviews | quote }}
+  MAX_FETCHED_REVIEW_COMMENTS: {{ $c.maxFetchedReviewComments | quote }}
+  MAX_FETCHED_FILES: {{ $c.maxFetchedFiles | quote }}
   AGENT_TIMEOUT_MS: {{ int $c.agentTimeoutMs | quote }}
   {{- if ne ($c.agentMaxTurns | toString) "" }}
   AGENT_MAX_TURNS: {{ $c.agentMaxTurns | quote }}

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -315,6 +315,10 @@ config:
   logLevel: info                                # fatal | error | warn | info | debug | trace.
   nodeEnv: production
   maxConcurrentRequests: 3
+  maxFetchedComments: 500
+  maxFetchedReviews: 500
+  maxFetchedReviewComments: 500
+  maxFetchedFiles: 500
   agentTimeoutMs: 3600000                       # 60min wall-clock cap per agent step. Lower only for testing/smaller-scope deployments; non-trivial implement/review steps routinely run 30-50min.
   agentMaxTurns: ""                             # Leave empty for no turn cap (recommended). Set to a positive int only when ops needs a hard ceiling; overrides defaultMaxTurns when both are set.
   claudeCodePath: ""                            # Required only when claude-code is installed globally (e.g. Docker).


### PR DESCRIPTION
## Summary

Bumps the `github-app-playground` Helm chart to **v0.12.0** and `appVersion` to **v1.9.1** ([upstream release](https://github.com/chrisleekr/github-app-playground/releases/tag/v1.9.1)).

