### PR TITLE
fix(github-app-playground): bump chart to v0.13.1 / appVersion 1.10.1

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.13.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.10.0"
+appVersion: "1.10.1"
 
 kubeVersion: ">= 1.31.0"
 
@@ -46,6 +46,8 @@ sources:
 annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
+    - kind: fixed
+      description: "Bumped appVersion to 1.10.1. Executor now captures Claude CLI stderr via SDK callback so failures surface in logs instead of being swallowed (upstream #105). Internal fix only — no chart values, env vars, or template surface changes."
     - kind: added
       description: "Bumped appVersion to 1.10.0. Exposes 5 new optional env vars mirroring src/config.ts: `secrets.githubPersonalAccessToken` (group 3, PAT override — single-tenant only, app hard-fails unless `config.allowedOwners` has exactly one owner), `secrets.daemonAuthTokenPrevious` (group 8, rotation-window predecessor for orchestrator-side daemon Bearer auth), and group 10b LLM output-scanner tunables (`config.llmOutputScannerEnabled`, `config.llmOutputScannerModel`, `config.llmOutputScannerTimeoutMs`)."
     - kind: added


### PR DESCRIPTION
## Summary
- Bump chart `0.13.0` → `0.13.1`, appVersion `1.10.0` → `1.10.1`
- Pulls upstream v1.10.1 patch: executor captures Claude CLI stderr via SDK callback so failures surface in logs instead of being swallowed (chrisleekr/github-app-playground#105)
- Internal app fix only — no chart values, env vars, or template surface changes
- ArtifactHub changelog updated with `kind: fixed` entry

## Verification
- Verified upstream `v1.10.0...v1.10.1` diff: only `src/core/executor.ts`, `test/core/executor.test.ts`, `package.json`, `CHANGELOG.md` changed
- No `src/config.ts` or `.env.example` changes — chart surface unchanged

## Test plan
- [x] `helm lint charts/github-app-playground` — passes
- [x] `helm template charts/github-app-playground` — renders cleanly
- [ ] CI lint workflow passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error visibility during executor operations.

* **Chores**
  * Updated Helm chart version to 0.13.1 and app version to 1.10.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->