### PR TITLE
fix(github-app-playground): bump chart to v0.13.2 / appVersion 1.10.2

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.1
+version: 0.13.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.10.1"
+appVersion: "1.10.2"
 
 kubeVersion: ">= 1.31.0"
 
@@ -46,6 +46,8 @@ sources:
 annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
+    - kind: fixed
+      description: "Bumped appVersion to 1.10.2. Executor drops the `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` flag that was blocking Claude CLI startup (upstream #106). Internal fix only — no chart values, env vars, or template surface changes."
     - kind: fixed
       description: "Bumped appVersion to 1.10.1. Executor now captures Claude CLI stderr via SDK callback so failures surface in logs instead of being swallowed (upstream #105). Internal fix only — no chart values, env vars, or template surface changes."
     - kind: added


### PR DESCRIPTION
## Summary

Tracks upstream `github-app-playground` v1.10.2 patch release (https://github.com/chrisleekr/github-app-playground/releases/tag/v1.10.2).

The upstream fix drops the `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` env flag that was blocking Claude CLI startup in the executor (upstream #106). It is an internal-only behavior change — `src/config.ts` and `.env.example` are untouched, so the chart's values surface, env wiring, and templates do not need any changes. Operators upgrade by bumping the image tag.

```mermaid
flowchart LR
  classDef before fill:#7c2d12,stroke:#fed7aa,stroke-width:2px,color:#fff7ed
  classDef after  fill:#14532d,stroke:#bbf7d0,stroke-width:2px,color:#f0fdf4

  Before["Chart 0.13.1<br/>appVersion 1.10.1<br/>executor sets<br/>CLAUDE_CODE_SUBPROCESS_ENV_SCRUB<br/>CLI startup blocked"]:::before
  After["Chart 0.13.2<br/>appVersion 1.10.2<br/>flag removed<br/>CLI starts cleanly"]:::after

  Before --> After
```

## Changes

- `charts/github-app-playground/Chart.yaml`
  - `version`: `0.13.1` → `0.13.2` (patch — chart-level changes are limited to appVersion + changelog metadata)
  - `appVersion`: `"1.10.1"` → `"1.10.2"`
  - `artifacthub.io/changes`: prepended one `kind: fixed` entry citing upstream #106 and explicitly noting no values/template surface impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Application version bumped to 1.10.2
  * Helm chart version updated to 0.13.2
  * Deployment configuration and metadata updated to align with the latest application release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->