### PR TITLE
feat(github-app-playground): bump chart to v0.14.0 / appVersion 1.11.0

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.2
+version: 0.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.10.2"
+appVersion: "1.11.0"
 
 kubeVersion: ">= 1.31.0"
 
@@ -46,6 +46,10 @@ sources:
 annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
+    - kind: added
+      description: "Bumped appVersion to 1.11.0. Resolve workflow now gates handler success on post-fix CI state (upstream #107). Internal logic only — no chart values, env vars, or template surface changes."
+    - kind: fixed
+      description: "Bumped appVersion to 1.11.0. Implement workflow now matches PR author by login in PAT mode (upstream #108). Internal fix only — no chart values, env vars, or template surface changes."
     - kind: fixed
       description: "Bumped appVersion to 1.10.2. Executor drops the `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` flag that was blocking Claude CLI startup (upstream #106). Internal fix only — no chart values, env vars, or template surface changes."
     - kind: fixed


### PR DESCRIPTION
## Summary

Track upstream [github-app-playground v1.11.0](https://github.com/chrisleekr/github-app-playground/releases/tag/v1.11.0) release. App-level minor bump (feat #107 + fix #108) with **zero chart surface changes** — no new env vars, secrets, values, or template edits. Chart version bumped minor (`0.13.2 → 0.14.0`) to mirror the app's minor semantic intent.

### Upstream changes

- 🟣 **feat(resolve):** gate handler success on post-fix CI state ([#107](https://github.com/chrisleekr/github-app-playground/pull/107))
- 🔴 **fix(implement):** match PR author by login in PAT mode ([#108](https://github.com/chrisleekr/github-app-playground/pull/108))

### Diff verification (v1.10.2 → v1.11.0)

| Surface | Changed? |
|---|---|
| `src/config.ts` | ❌ |
| `.env.example` | ❌ |
| New env vars | ❌ |
| New secrets / volumes / ports | ❌ |
| DB schema | ✅ migration `009_workflow_runs_incomplete.sql` (auto-applied at app startup; no chart action required) |

```mermaid
flowchart LR
    BeforeChart["chart 0.13.2<br/>appVersion 1.10.2"]:::before
    AfterChart["chart 0.14.0<br/>appVersion 1.11.0"]:::after
    NoSurfaceChange["values.yaml / configmap / secret<br/>UNCHANGED"]:::keep
    BeforeChart --> AfterChart
    AfterChart --> NoSurfaceChange
    classDef before fill:#7f1d1d,stroke:#fecaca,color:#ffffff
    classDef after fill:#14532d,stroke:#bbf7d0,color:#ffffff
    classDef keep fill:#1e3a8a,stroke:#bfdbfe,color:#ffffff
```

## Changes

- `charts/github-app-playground/Chart.yaml`
  - `version`: `0.13.2` → `0.14.0`
  - `appVersion`: `1.10.2` → `1.11.0`
  - `artifacthub.io/changes`: prepended 2 entries (added: resolve CI gating; fixed: PAT-mode PR author match)

## Verification

- ✅ `helm lint charts/github-app-playground/` clean (only pre-existing icon recommendation)
- ✅ `helm template charts/github-app-playground/` renders successfully
- ✅ Single file modified — no template / values changes

## Test plan

- [x] Helm lint passes
- [x] Helm template renders
- [ ] CI lint workflow passes
- [ ] CodeRabbit review clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Helm chart updated to version 0.14.0
  * Application updated to version 1.11.0
  * Release documentation updated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->