### PR TITLE
feat(github-app-playground): bump chart to v0.15.0 / appVersion 1.12.0

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.1
+version: 0.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.11.1"
+appVersion: "1.12.0"
 
 kubeVersion: ">= 1.31.0"
 
@@ -46,6 +46,18 @@ sources:
 annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
+    - kind: added
+      description: "Bumped appVersion to 1.12.0. Exposes 5 new optional config keys mirroring src/config.ts: `config.triageToolsEnabled` (group 10, kill-switch for tool-driven triage classifier) and group 10a chat-thread executor tunables (`config.chatThreadExecuteThreshold`, `config.chatThreadProposalTtlHours`, `config.chatThreadMaxTurns`, `config.chatThreadToolsEnabled`)."
+    - kind: added
+      description: "Tool-driven LLM with a new in-process `github-state` MCP server (upstream #117/#118): triage and chat-thread agents now fetch fresh PR state on demand instead of relying on a snapshot. Internal architecture only — no chart values, env vars, or template surface changes."
+    - kind: added
+      description: "Chat-thread executor (upstream #113): conversational scoped intent path with structured-output chokepoint and OAuth gate fix. Default ON via the new `config.chatThread*` tunables."
+    - kind: added
+      description: "Defense layer 5 (upstream #121): hardens bot against prompt-injection comment attacks. Adds Unicode TAG-block stripping, nonced spotlight tags, and routes every remaining Phase-2 GitHub write path through `safePostToGitHub`. Internal hardening only — no chart values or template surface changes."
+    - kind: fixed
+      description: "Bumped appVersion to 1.12.0. Sanitizes attacker-controlled filenames in `formatChangedFiles` (upstream #110). Internal fix only — no chart values, env vars, or template surface changes."
+    - kind: fixed
+      description: "Bumped appVersion to 1.12.0. Reroutes iteration-0 terminal-bad ship verdicts to chat-thread (upstream #119/#120). Internal fix only — no chart values, env vars, or template surface changes."
     - kind: fixed
       description: "Bumped appVersion to 1.11.1. Tracking-mirror setState is now idempotent via embedded run markers and orphan adoption, eliminating duplicate tracking comments caused by octokit retry on transient 5xx (upstream #109/#111). Internal fix only — no chart values, env vars, or template surface changes."
     - kind: added

--- a/charts/github-app-playground/templates/configmap.yaml
+++ b/charts/github-app-playground/templates/configmap.yaml
@@ -87,11 +87,18 @@ data:
 
   # --- 9. Triage (binary heavy classifier) ---
   TRIAGE_ENABLED: {{ $c.triageEnabled | quote }}
+  TRIAGE_TOOLS_ENABLED: {{ $c.triageToolsEnabled | quote }}
   TRIAGE_MODEL: {{ $c.triageModel | quote }}
   TRIAGE_CONFIDENCE_THRESHOLD: {{ $c.triageConfidenceThreshold | quote }}
   TRIAGE_MAX_TOKENS: {{ $c.triageMaxTokens | quote }}
   TRIAGE_TIMEOUT_MS: {{ $c.triageTimeoutMs | quote }}
   INTENT_CONFIDENCE_THRESHOLD: {{ $c.intentConfidenceThreshold | quote }}
+
+  # --- 10a. Chat-thread executor (conversational scoped intent) ---
+  CHAT_THREAD_EXECUTE_THRESHOLD: {{ $c.chatThreadExecuteThreshold | quote }}
+  CHAT_THREAD_PROPOSAL_TTL_HOURS: {{ $c.chatThreadProposalTtlHours | quote }}
+  CHAT_THREAD_MAX_TURNS: {{ $c.chatThreadMaxTurns | quote }}
+  CHAT_THREAD_TOOLS_ENABLED: {{ $c.chatThreadToolsEnabled | quote }}
 
   # --- 10b. LLM-based output scanner (defense layer 4) ---
   LLM_OUTPUT_SCANNER_ENABLED: {{ $c.llmOutputScannerEnabled | quote }}

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -359,11 +359,21 @@ config:
 
   # --- 9. Triage (binary heavy classifier) ---
   triageEnabled: true                           # Kill-switch for the triage LLM call.
+  triageToolsEnabled: true                      # Kill-switch for tool-driven triage (upstream #117). When false, falls back to snapshot-only triage classifier.
   triageModel: sonnet-4-6
   triageConfidenceThreshold: 1.0                # Lower to 0.75 only after SC-003/SC-004 stabilise.
   triageMaxTokens: 256
   triageTimeoutMs: 5000
   intentConfidenceThreshold: 0.75               # Below this, the dispatcher treats the comment as ambiguous and posts a clarification request (FR-009). Matches SC-005 target band.
+
+  # --- 10a. Chat-thread executor (conversational scoped intent) ---
+  # Tunables for the chat-thread workflow (added in app v1.12.0). Drives the
+  # conversational dispatch path that runs after triage with full PR context,
+  # producing a proposal that the user reacts to before workflow dispatch.
+  chatThreadExecuteThreshold: 0.8               # Minimum LLM confidence required to dispatch directly from chat-thread without going through the human-confirm proposal gate. Stricter than intentConfidenceThreshold because chat-thread runs with full PR context.
+  chatThreadProposalTtlHours: 24                # TTL for awaiting chat-thread proposals. After this point the proposal-poller transitions the row to `expired` and any subsequent reaction is logged-but-ignored.
+  chatThreadMaxTurns: 8                         # Per-AWAITING-PROPOSAL cap on conversational turns. Once hit, chat-thread declines further LLM work and tells the user to react. Reset on proposal status transition.
+  chatThreadToolsEnabled: true                  # Kill-switch for chat-thread's tool-call path (upstream #117). When false, falls back to snapshot-only context.
 
   # --- 10b. LLM-based output scanner (defense layer 4) ---
   # Second-pass LLM scan on every agent-generated body before it is posted to


### PR DESCRIPTION
## Summary

Bump `github-app-playground` Helm chart to `v0.15.0` and `appVersion` to `1.12.0`, tracking upstream [v1.12.0](https://github.com/chrisleekr/github-app-playground/releases/tag/v1.12.0).

**New chart values** (5 keys, all optional with safe defaults matching upstream Zod schema):

- `config.triageToolsEnabled` (default `true`) — kill-switch for tool-driven triage classifier (upstream #117)
- `config.chatThreadExecuteThreshold` (default `0.8`) — direct-dispatch confidence floor for chat-thread (upstream #113)
- `config.chatThreadProposalTtlHours` (default `24`) — TTL for awaiting chat-thread proposals
- `config.chatThreadMaxTurns` (default `8`) — per-AWAITING-PROPOSAL turn cap
- `config.chatThreadToolsEnabled` (default `true`) — kill-switch for chat-thread's tool-call path

**Internal-only upstream changes (no chart surface impact):**

- Tool-driven LLM with new in-process `github-state` MCP server (#117/#118)
- Prompt-injection comment-attack hardening: Unicode TAG-block strip, nonced spotlight tags, output chokepoint coverage (#121)
- Ship: iteration-0 terminal-bad verdicts rerouted to chat-thread (#119/#120)
- Security: sanitize attacker-controlled filenames in `formatChangedFiles` (#110)
- DB migrations `010_chat_proposals.sql` and `011_conversation_cache.sql` are auto-applied at startup

## Test plan

- [x] \`helm lint charts/github-app-playground\` — clean
- [x] \`helm template charts/github-app-playground\` renders new env vars with correct defaults: \`TRIAGE_TOOLS_ENABLED=\"true\"\`, \`CHAT_THREAD_EXECUTE_THRESHOLD=\"0.8\"\`, \`CHAT_THREAD_PROPOSAL_TTL_HOURS=\"24\"\`, \`CHAT_THREAD_MAX_TURNS=\"8\"\`, \`CHAT_THREAD_TOOLS_ENABLED=\"true\"\`
- [ ] CI lint + release-dry-run workflow green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v1.12.0

* **New Features**
  * Added a triage tools configuration option to enable or disable tool-driven triage functionality
  * Introduced a chat-thread executor feature with configurable settings for execution thresholds, proposal TTL, maximum conversation turns, and tool usage control

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/helm-charts/pull/37)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->