### PR TITLE
fix(github-app-playground): bump chart to v0.15.1 / appVersion 1.12.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /charts/*/charts
 .DS_Store
 /charts/*/template
+
+.claude

--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.0
+version: 0.15.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.12.0"
+appVersion: "1.12.1"
 
 kubeVersion: ">= 1.31.0"
 
@@ -46,6 +46,8 @@ sources:
 annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
+    - kind: fixed
+      description: "Bumped appVersion to 1.12.1. Restores per-line inline review comments on PRs by resolving `github_comment` and `github_inline_comment` MCP server scripts via `import.meta.url` so the SDK can spawn them from the cloned-repo workDir, and disallows `ToolSearch` so the model trusts the eager tool list (upstream #123). Internal fix only — no chart values, env vars, or template surface changes."
     - kind: added
       description: "Bumped appVersion to 1.12.0. Exposes 5 new optional config keys mirroring src/config.ts: `config.triageToolsEnabled` (group 10, kill-switch for tool-driven triage classifier) and group 10a chat-thread executor tunables (`config.chatThreadExecuteThreshold`, `config.chatThreadProposalTtlHours`, `config.chatThreadMaxTurns`, `config.chatThreadToolsEnabled`)."
     - kind: added


### PR DESCRIPTION
## Summary

Bumps the `github-app-playground` Helm chart to track upstream patch release [v1.12.1](https://github.com/chrisleekr/github-app-playground/releases/tag/v1.12.1).

- Chart `version`: `0.15.0` → `0.15.1`
- `appVersion`: `1.12.0` → `1.12.1`
- Adds `kind: fixed` changelog entry under `artifacthub.io/changes`
- Also ignores local `.claude` directory

## Upstream change

Upstream [#123](https://github.com/chrisleekr/github-app-playground/pull/123) — `fix(bot): restore inline review comments on PRs`. Two compounding bugs:

1. `github_comment` and `github_inline_comment` MCP server defs in `src/mcp/registry.ts` resolved their server scripts with bare relative args. The Agent SDK spawns MCP subprocesses with `cwd` set to the cloned-repo workDir where no `dist/` exists, so both servers exited ENOENT and the model never saw the inline-comment tools.
2. The model fell back to `ToolSearch` (a Claude Code harness tool that lists *deferred* tools) and concluded its MCP tools were unloaded. Pinning `disallowedTools: ["ToolSearch"]` forces the model to trust the eager tool list from the SDK init message.

Pure internal fix — no new env vars, no chart values changed, no template surface changes.

## Test plan

- [x] `helm lint charts/github-app-playground` passes
- [x] `helm template charts/github-app-playground` renders cleanly (277 lines, all 5 v1.12.0 env vars still wired correctly)
- [ ] CI lint workflow passes
- [ ] Chart releaser publishes `github-app-playground-0.15.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored inline review comments functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/helm-charts/pull/38)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->