### PR TITLE
fix(github-app-playground): bump chart to v0.15.2 / appVersion 1.12.2

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.1
+version: 0.15.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.12.1"
+appVersion: "1.12.2"
 
 kubeVersion: ">= 1.31.0"
 
@@ -45,7 +45,12 @@ sources:
 
 annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
+  artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
+    - kind: fixed
+      description: "Bumped appVersion to 1.12.2. Bundles all stdio MCP servers (`github_comment`, `github_inline_comment`, `github_state`, `repo_memory`) and resolves their script paths from any bundle layout via a shared resolver (upstream #125). Internal fix only — no chart values, env vars, or template surface changes."
+    - kind: security
+      description: "Bumped appVersion to 1.12.2. Closes a cross-session prompt-injection vector via `repo_memory`: sanitizes attacker-controlled content before it is stored or replayed into prompts, and adds a backfill migration for existing rows (upstream #124). Internal hardening only — no chart values, env vars, or template surface changes."
     - kind: fixed
       description: "Bumped appVersion to 1.12.1. Restores per-line inline review comments on PRs by resolving `github_comment` and `github_inline_comment` MCP server scripts via `import.meta.url` so the SDK can spawn them from the cloned-repo workDir, and disallows `ToolSearch` so the model trusts the eager tool list (upstream #123). Internal fix only — no chart values, env vars, or template surface changes."
     - kind: added


### PR DESCRIPTION
## Summary

Track upstream `github-app-playground` [v1.12.2](https://github.com/chrisleekr/github-app-playground/releases/tag/v1.12.2). Both upstream changes are internal-only — no chart values, env vars, or template surface changes — so this is a pure patch bump (`0.15.1 → 0.15.2`, appVersion `1.12.1 → 1.12.2`).

Upstream contents:
- **#125 (fix, mcp)** — bundle all stdio MCP servers (`github_comment`, `github_inline_comment`, `github_state`, `repo_memory`) and resolve script paths from any bundle layout via a shared resolver.
- **#124 (security)** — close a cross-session prompt-injection vector via `repo_memory`: sanitize attacker-controlled content before it is stored or replayed into prompts, with a backfill migration for existing rows.

Because #124 is a security mitigation, this release also flips on `artifacthub.io/containsSecurityUpdates: "true"` so ArtifactHub renders the security badge, and the corresponding changelog entry uses `kind: security` instead of `kind: fixed` per the [ArtifactHub annotations schema](https://artifacthub.io/docs/topics/annotations/helm/).

```mermaid
flowchart LR
  subgraph Bump["github-app-playground chart bump"]
    Before["v0.15.1<br/>appVersion 1.12.1<br/>no security badge"]:::before
    After["v0.15.2<br/>appVersion 1.12.2<br/>containsSecurityUpdates: true<br/>+ kind: security entry #124<br/>+ kind: fixed entry #125"]:::after
    Before --> After
  end

  classDef before fill:#ecf0f1,color:#2c3e50,stroke:#7f8c8d
  classDef after fill:#1e8449,color:#ffffff,stroke:#145a32
```

## Changes

- `charts/github-app-playground/Chart.yaml`
  - `version`: `0.15.1` → `0.15.2`
  - `appVersion`: `"1.12.1"` → `"1.12.2"`
  - Add `artifacthub.io/containsSecurityUpdates: "true"` annotation
  - Add `kind: fixed` changelog entry for upstream #125 (MCP stdio bundle path resolution)
  - Add `kind: security` changelog entry for upstream #124 (`repo_memory` cross-session prompt-injection fix + backfill migration)

## Verification

- `helm lint charts/github-app-playground` → passes
- `gh api repos/chrisleekr/github-app-playground/compare/v1.12.1...v1.12.2` → confirmed zero changes to config/env files upstream, so `values.yaml` and `configmap.yaml` correctly require no updates
