### PR TITLE
feat(github-app-playground): bump chart to v0.16.0 / appVersion 1.13.0

### DIFF
--- a/charts/github-app-playground/Chart.yaml
+++ b/charts/github-app-playground/Chart.yaml
@@ -17,13 +17,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.2
+version: 0.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.12.2"
+appVersion: "1.13.0"
 
 kubeVersion: ">= 1.31.0"
 
@@ -45,8 +45,21 @@ sources:
 
 annotations:
   # https://artifacthub.io/docs/topics/annotations/helm/
-  artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
+    - kind: added
+      description: "Bumped appVersion to 1.13.0. Exposes 8 new optional config keys mirroring src/config.ts: `config.digestModel` (group 9, comment-aware workflows digest model), `config.promptCacheLayout` (group 12a, prompt cache layout selector — chart default flipped to `cacheable` to opt into cache hits), and group 14 scheduled-actions tunables (`config.schedulerEnabled` — chart default `true`, `config.schedulerScanIntervalMs`, `config.schedulerAllowAutoMerge`, `config.schedulerConfigFile`, `config.reviewLearningsEnabled`, `config.reviewLearningsRagEnabled` — chart default `true`)."
+    - kind: added
+      description: "Scheduled actions via `.github-app.yaml` (upstream #159): scheduler walks installed repos on a cron and enqueues per-repo declarative actions. Chart default ON via `config.schedulerEnabled: true`; `config.schedulerAllowAutoMerge` left OFF (privilege gate for the `merge_readiness` MCP tool — opt-in per deployment)."
+    - kind: added
+      description: "Persistent review-learnings (upstream #160/#161/#162): per-repo review-policy directives saved via `@bot remember` or autonomous capture, replayed into prompts. Chart default ON via `config.reviewLearningsEnabled: true`. Stage 2 RAG path (`config.reviewLearningsRagEnabled: true`) enabled by chart default — requires Postgres migration 015 (pgvector extension) to be applied; if missing, falls back to legacy file-glob filter."
+    - kind: added
+      description: "Comment-aware structured workflows (upstream #148): LLM digest distills issue/PR comment threads into guidance for structured workflows. Model selected via new `config.digestModel` (default `sonnet-4-6`)."
+    - kind: added
+      description: "Opt-in cacheable system/user prompt split (upstream #135): lifts static prompt scaffolding into `systemPrompt.append` with `excludeDynamicSections: true` so the Anthropic prompt cache hits across jobs. Chart default flipped to `cacheable`. Operators should verify non-zero `cacheReadInputTokens` in executor logs after rollout."
+    - kind: fixed
+      description: "Bumped appVersion to 1.13.0. Webhook subscribes `issue_comment.edited`/`.deleted` (upstream #131) and write-through populates `target_cache` on `issues`/`pull_request` events (upstream #130/#132). Internal fix only — no chart values, env vars, or template surface changes."
+    - kind: fixed
+      description: "Bumped appVersion to 1.13.0. Dependency bumps: `@anthropic-ai/bedrock-sdk` ^0.29.0 (upstream #147) and `@anthropic-ai/claude-agent-sdk` ^0.3.0 (upstream #154). Internal updates only — no chart surface changes."
     - kind: fixed
       description: "Bumped appVersion to 1.12.2. Bundles all stdio MCP servers (`github_comment`, `github_inline_comment`, `github_state`, `repo_memory`) and resolves their script paths from any bundle layout via a shared resolver (upstream #125). Internal fix only — no chart values, env vars, or template surface changes."
     - kind: security

--- a/charts/github-app-playground/templates/configmap.yaml
+++ b/charts/github-app-playground/templates/configmap.yaml
@@ -89,6 +89,7 @@ data:
   TRIAGE_ENABLED: {{ $c.triageEnabled | quote }}
   TRIAGE_TOOLS_ENABLED: {{ $c.triageToolsEnabled | quote }}
   TRIAGE_MODEL: {{ $c.triageModel | quote }}
+  DISCUSSION_DIGEST_MODEL: {{ $c.digestModel | quote }}
   TRIAGE_CONFIDENCE_THRESHOLD: {{ $c.triageConfidenceThreshold | quote }}
   TRIAGE_MAX_TOKENS: {{ $c.triageMaxTokens | quote }}
   TRIAGE_TIMEOUT_MS: {{ $c.triageTimeoutMs | quote }}
@@ -115,6 +116,9 @@ data:
   REVIEW_RESOLVE_MAX_ITERATIONS: {{ $c.reviewResolveMaxIterations | quote }}
   {{- end }}
 
+  # --- 12a. Prompt cache layout ---
+  PROMPT_CACHE_LAYOUT: {{ $c.promptCacheLayout | quote }}
+
   # --- 13. Ship workflow (PR shepherding to merge-ready) ---
   MAX_WALL_CLOCK_PER_SHIP_RUN: {{ $c.maxWallClockPerShipRun | quote }}
   MAX_SHIP_ITERATIONS: {{ $c.maxShipIterations | quote }}
@@ -125,3 +129,11 @@ data:
   {{- if $c.shipForbiddenTargetBranches }}
   SHIP_FORBIDDEN_TARGET_BRANCHES: {{ $c.shipForbiddenTargetBranches | quote }}
   {{- end }}
+
+  # --- 14. Scheduled actions + review-learnings ---
+  SCHEDULER_ENABLED: {{ $c.schedulerEnabled | quote }}
+  SCHEDULER_SCAN_INTERVAL_MS: {{ int $c.schedulerScanIntervalMs | quote }}
+  SCHEDULER_ALLOW_AUTO_MERGE: {{ $c.schedulerAllowAutoMerge | quote }}
+  SCHEDULER_CONFIG_FILE: {{ $c.schedulerConfigFile | quote }}
+  REVIEW_LEARNINGS_ENABLED: {{ $c.reviewLearningsEnabled | quote }}
+  REVIEW_LEARNINGS_RAG_ENABLED: {{ $c.reviewLearningsRagEnabled | quote }}

--- a/charts/github-app-playground/values.yaml
+++ b/charts/github-app-playground/values.yaml
@@ -361,6 +361,7 @@ config:
   triageEnabled: true                           # Kill-switch for the triage LLM call.
   triageToolsEnabled: true                      # Kill-switch for tool-driven triage (upstream #117). When false, falls back to snapshot-only triage classifier.
   triageModel: sonnet-4-6
+  digestModel: sonnet-4-6                       # Model for the discussion-digest LLM call (upstream #148, src/workflows/discussion-digest.ts). Distills issue/PR comment threads into guidance for the structured workflows. Sonnet default — reduce-merge precedence and low-hallucination extraction need the reasoning headroom.
   triageConfidenceThreshold: 1.0                # Lower to 0.75 only after SC-003/SC-004 stabilise.
   triageMaxTokens: 256
   triageTimeoutMs: 5000
@@ -391,6 +392,19 @@ config:
   # --- 12. Composite ship review/resolve loop ---
   reviewResolveMaxIterations: ""                # Leave empty to use the upstream default (2). Range: 1–5. Caps how many review→resolve passes the ship pipeline runs before terminating with a manual-re-review hint when findings remain.
 
+  # --- 12a. Prompt cache layout (upstream #134/#135) ---
+  # `legacy`: single user-role string; system prompt embeds dynamic sections
+  #   (cwd, platform, shell, OS). Because cwd is unique per delivery (per-event
+  #   mkdtemp), the prefix is unique per job and the Anthropic prompt cache
+  #   misses every invocation.
+  # `cacheable`: lifts static scaffolding (security_directive, freshness_directive,
+  #   workflow steps, commit/CAPABILITIES boilerplate) into `systemPrompt.append`
+  #   with `excludeDynamicSections: true`. System-prompt prefix is byte-identical
+  #   across jobs of the same shape and reused via the prompt cache.
+  # Chart default `cacheable`; verify non-zero `cacheReadInputTokens` in executor
+  # completion logs after rollout. Revert to `legacy` if cache hits stay zero.
+  promptCacheLayout: cacheable                  # legacy | cacheable.
+
   # --- 13. Ship workflow (PR shepherding to merge-ready) ---
   # Tunables for the upstream `bot:ship` workflow (added in app v1.7.0). All
   # have sensible defaults — override only when the deployment needs a
@@ -402,6 +416,19 @@ config:
   reviewBarrierSafetyMarginMs: 1200000          # 20min. Single global safety margin for the reviewer-latency barrier. When no non-bot review is observed on the current head SHA, the barrier defers `ready` until at least this much time has elapsed since the most recent push. Single-knob design is intentional — no reviewer-login list is carried anywhere.
   fixAttemptsPerSignatureCap: 3                 # Per-(intent, signature) cap on resolve/review fix attempts. On reaching this count for a derived signature, the next attempt halts with `BlockerCategory='flake-cap'`. Backed by the `ship_fix_attempts` table.
   shipForbiddenTargetBranches: ""               # Eligibility gate. Comma-separated list of branch names the bot must refuse to shepherd against (e.g. `main,master,release`). Empty (default) imposes no branch restriction beyond the standard owner/fork/state checks.
+
+  # --- 14. Scheduled actions + review-learnings (upstream #159, #160, #161, #162) ---
+  # Scheduled actions: scheduler walks each installation's repos on a cron,
+  # fetches `.github-app.yaml` from the default branch, and enqueues any action
+  # whose cron slot is due. Server mode only — daemon processes ignore.
+  # Review-learnings: per-repo review-policy directives saved via explicit
+  # `@bot remember` or autonomous capture, replayed into prompts at job time.
+  schedulerEnabled: true                        # Chart default ON (upstream defaults OFF). Master kill-switch for the scheduler. When false the scheduler never starts.
+  schedulerScanIntervalMs: 300000               # Tick cadence (5m). Zod range [60000, 3600000]. Below 60s the per-tick GitHub API cost is not worth it; above 1h cron precision degrades.
+  schedulerAllowAutoMerge: false                # Privilege gate for the `merge_readiness` MCP tool. When true (and an action sets `auto_merge: true`), the tool can merge PRs. Does NOT sandbox the agent from merging by other means: `allowed_tools` is owner-trusted config. Default OFF — opt-in per deployment.
+  schedulerConfigFile: ".github-app.yaml"       # Filename the scheduler reads from each installed repo's default-branch root.
+  reviewLearningsEnabled: true                  # Master kill-switch for review-learnings. When false the orchestrator never loads learnings into job:payload, the prompt block stays empty, and save/delete MCP calls are dropped. Additive feature — safe to leave ON.
+  reviewLearningsRagEnabled: true               # Chart default ON (upstream defaults OFF). Stage 2 pgvector RAG path: orchestrator embeds each directive at save time + each PR's changed-file paths at handleAccept, then runs pgvector top-K against `review_learnings.embedding`. REQUIRES Postgres migration 015 (pgvector extension); if missing or migration not applied, falls back to legacy file-glob filter.
 
 # ─────────────────────────── DAEMON POOLS ─────────────────────────────
 # `daemon:` configures 0..N stateless daemon worker pools. Each pool


### PR DESCRIPTION
## Summary

Tracks upstream [`github-app-playground v1.13.0`](https://github.com/chrisleekr/github-app-playground/releases/tag/v1.13.0). This release adds four new feature surfaces (scheduled actions, persistent review-learnings, comment-aware structured workflows, cacheable prompt split) and an LLM digest model, requiring 8 new optional config keys on the chart.

User intent: **default-enable all new features**. Chart-level defaults intentionally diverge from upstream Zod defaults for four keys (`promptCacheLayout`, `schedulerEnabled`, `reviewLearningsRagEnabled`, `reviewLearningsEnabled` — last already ON upstream). The privilege-sensitive `schedulerAllowAutoMerge` is left OFF to require explicit opt-in.

### Before

```mermaid
flowchart LR
  chart["chart 0.15.2<br/>appVersion 1.12.2"]:::before --> values["values.yaml<br/>group 9, 10a, 10b, 12, 13"]:::before
  chart --> cm["configmap.yaml<br/>renders ~40 env keys"]:::before
  classDef before fill:#7f1d1d,color:#ffffff
```

### After

```mermaid
flowchart LR
  chart["chart 0.16.0<br/>appVersion 1.13.0"]:::after --> values["values.yaml<br/>+ group 12a promptCacheLayout<br/>+ group 9 digestModel<br/>+ group 14 scheduler + review-learnings"]:::after
  chart --> cm["configmap.yaml<br/>+ 8 new env keys"]:::after
  values --> defaults["chart defaults<br/>promptCacheLayout=cacheable<br/>schedulerEnabled=true<br/>reviewLearningsEnabled=true<br/>reviewLearningsRagEnabled=true<br/>schedulerAllowAutoMerge=false"]:::after
  classDef after fill:#14532d,color:#ffffff
```

## Changes

**Chart.yaml**
- Bump `version` `0.15.2` → `0.16.0` (minor — new value surface)
- Bump `appVersion` `"1.12.2"` → `"1.13.0"`
- Remove `artifacthub.io/containsSecurityUpdates` annotation (v1.13.0 has no explicit security fix)
- Add 7 new `artifacthub.io/changes` entries covering new features, internal fixes, and dep bumps

**values.yaml** — 8 new keys, grouped to match upstream `src/config.ts`:
- Group 9: `config.digestModel: sonnet-4-6` — discussion-digest LLM model (upstream #148)
- Group 12a: `config.promptCacheLayout: cacheable` — opt-in prompt cache layout (upstream #135). **Chart default diverges from upstream `legacy`**
- Group 14: scheduled actions + review-learnings (upstream #159, #160, #161, #162)
  - `config.schedulerEnabled: true` — **diverges from upstream `false`**
  - `config.schedulerScanIntervalMs: 300000`
  - `config.schedulerAllowAutoMerge: false` — kept OFF (matches upstream; privilege gate for the `merge_readiness` MCP tool)
  - `config.schedulerConfigFile: ".github-app.yaml"`
  - `config.reviewLearningsEnabled: true`
  - `config.reviewLearningsRagEnabled: true` — **diverges from upstream `false`; requires Postgres migration 015 (pgvector). Falls back to legacy file-glob filter if migration not applied**

**templates/configmap.yaml** — renders the 8 new env vars matching the upstream `process.env[…]` lookups:
- `DISCUSSION_DIGEST_MODEL`, `PROMPT_CACHE_LAYOUT`, `SCHEDULER_ENABLED`, `SCHEDULER_SCAN_INTERVAL_MS`, `SCHEDULER_ALLOW_AUTO_MERGE`, `SCHEDULER_CONFIG_FILE`, `REVIEW_LEARNINGS_ENABLED`, `REVIEW_LEARNINGS_RAG_ENABLED`

## Verification

- `helm lint charts/github-app-playground` → 0 chart failures
- `helm template` confirms all 8 new env keys render with the expected chart defaults
- Senior review (Phase 0.6) returned 0 findings; env var names cross-checked against upstream `src/config.ts` `loadConfig()` exactly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable LLM model selection for discussion digests
  * Introduced prompt cache layout configuration for optimization
  * Added scheduler and review learnings configuration parameters

* **Chores**
  * Updated Helm chart version to 0.16.0 and application version to 1.13.0
  * Extended ConfigMap with new environment variables

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chrisleekr/helm-charts/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->